### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/examples/integrations/flask/app.py
+++ b/examples/integrations/flask/app.py
@@ -8,11 +8,12 @@ Run:
     flask run
 """
 
+import logging
+
 from flask import Flask, g, jsonify, request
 
 from devrev import DevRevClient
 from devrev.exceptions import DevRevError, NotFoundError
-import logging
 
 app = Flask(__name__)
 
@@ -87,7 +88,7 @@ def create_ticket():
         )
     except DevRevError as e:
         return jsonify({"error": str(e)}), 400
-    except KeyError as e:
+    except KeyError:
         logging.exception("Missing required field in ticket creation request")
         return jsonify({"error": "Missing required field in request body"}), 400
 


### PR DESCRIPTION
Potential fix for [https://github.com/mgmonteleone/py-dev-rev/security/code-scanning/5](https://github.com/mgmonteleone/py-dev-rev/security/code-scanning/5)

In general, to fix this kind of problem you avoid returning raw exception objects or their string representations to the user. Instead, you log the detailed error server-side (for debugging and monitoring) and send the client either a generic message or a carefully controlled/whitelisted message that does not depend on exception contents.

For this specific case, the best fix with minimal functional change is:
- Stop interpolating `e` into the response body.
- Provide a safe, explicit error message. Since the missing field names are known (`title` and `part_id`), we can send a generic validation error that does not depend on exception contents, such as `"Missing required field in request body"`.
- Optionally log the exception on the server side using Python’s standard `logging` module so that developers do not lose debugging information.

Concretely in `examples/integrations/flask/app.py`:
- Add an import for `logging` near the other imports.
- In the `except KeyError as e:` block, call `logging.exception(...)` or `logging.warning(...)` to log the full traceback.
- Replace the dynamic error message `f"Missing required field: {e}"` with a static or at least non-exception-derived message, e.g. `"Missing required field in request body"`.

This keeps the API behavior (400 on bad input) but removes the information exposure while still allowing developers to inspect logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
