### PR TITLE
fix: Add missing states to RevUserState enum

### DIFF
--- a/src/devrev/models/rev_users.py
+++ b/src/devrev/models/rev_users.py
@@ -24,10 +24,17 @@ from devrev.models.base import (
 
 
 class RevUserState(str, Enum):
-    """Rev user state enumeration."""
+    """Rev user state enumeration.
+
+    Values match the DevRev API 'user-state' schema.
+    """
 
     ACTIVE = "active"
+    DEACTIVATED = "deactivated"
     DELETED = "deleted"
+    LOCKED = "locked"
+    SHADOW = "shadow"
+    UNASSIGNED = "unassigned"
 
 
 class RevUser(DevRevResponseModel):


### PR DESCRIPTION
## Summary

Fixes #115 - The `RevUserState` enum was missing several states that the DevRev API can return.

## Changes

Updated `RevUserState` enum to include all 6 states from the DevRev API `user-state` schema:

| State | Description |
|-------|-------------|
| `ACTIVE` | Active user (existing) |
| `DEACTIVATED` | Deactivated user |
| `DELETED` | Deleted user (existing) |
| `LOCKED` | Locked user |
| `SHADOW` | Shadow user |
| `UNASSIGNED` | Unassigned user |

## Problem

When calling `rev_users.list()`, if any user had a state other than 'active' or 'deleted', Pydantic would raise a validation error:

```
1 validation error for RevUsersListResponse
rev_users.6.state
  Input should be 'active' or 'deleted' [type=enum, input_value='unassigned', input_type=str]
```

## Verification

- ✅ All 6 states match the `user-state` schema in `openapi-public.yaml` (lines 18722-18731)
- ✅ Manually tested parsing all 6 states
- ✅ Existing tests pass
- ✅ Linting passes

## Related

- Discovered during testing of mgmonteleone/pylon2devrev#80

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author