### PR TITLE
chore: Bump version to v2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,11 @@ FROM python:3.11-slim AS runtime
 # Metadata labels
 LABEL maintainer="Matthew G. Monteleone <matthewm@augmentcode.com>" \
       description="DevRev MCP Server - A Model Context Protocol server for the DevRev platform" \
-      version="1.0.0" \
+      version="2.2.0" \
       org.opencontainers.image.source="https://github.com/mgmonteleone/py-dev-rev" \
       org.opencontainers.image.title="DevRev MCP Server" \
       org.opencontainers.image.description="Production-ready MCP server for DevRev API integration" \
-      org.opencontainers.image.version="1.0.0" \
+      org.opencontainers.image.version="2.2.0" \
       org.opencontainers.image.licenses="MIT"
 
 # Set environment variables for Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "devrev-Python-SDK"
-version = "2.1.2"
+version = "2.2.0"
 description = "A modern, type-safe Python SDK for the DevRev API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/devrev_mcp/__init__.py
+++ b/src/devrev_mcp/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "1.0.0"
+__version__ = "2.2.0"


### PR DESCRIPTION
Bumps version to 2.2.0 for the DevRev MCP Server release.

### Changes
- `pyproject.toml`: `2.1.2` → `2.2.0`
- `src/devrev_mcp/__init__.py`: `1.0.0` → `2.2.0`
- `Dockerfile`: `1.0.0` → `2.2.0`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author