### PR TITLE
chore: Release v2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,11 @@ FROM python:3.11-slim AS runtime
 # Metadata labels
 LABEL maintainer="Matthew G. Monteleone <matthewm@augmentcode.com>" \
       description="DevRev MCP Server - A Model Context Protocol server for the DevRev platform" \
-      version="2.2.0" \
+      version="2.3.0" \
       org.opencontainers.image.source="https://github.com/mgmonteleone/py-dev-rev" \
       org.opencontainers.image.title="DevRev MCP Server" \
       org.opencontainers.image.description="Production-ready MCP server for DevRev API integration" \
-      org.opencontainers.image.version="2.2.0" \
+      org.opencontainers.image.version="2.3.0" \
       org.opencontainers.image.licenses="MIT"
 
 # Set environment variables for Python

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-02-11
+
+### Added
+- **Client-side re-ranking** for hybrid search — boosts results where query is a substring of display_name/title
+- **Dynamic `_extract_display_name`** — supports all 35 DevRev namespace types for re-ranking
+- **MCP Inspector compatibility** — `__main__.py` uses `parse_known_args()` to handle extra arguments
+
+### Fixed
+- **SDK: SearchNamespace enum** — Expanded from 9 to 35 values matching all API-supported namespaces
+- **SDK: Namespace serialization** — Fixed `namespaces` (plural) → `namespace` (singular) via `serialization_alias`
+- **SDK: Namespace type** — Fixed from `list[SearchNamespace]` to single `SearchNamespace` value
+- **SDK: SearchResult model** — Restructured with entity-specific dicts, added `modified_date` and `comments` fields
+- **SDK: Limit validation** — Added `Field(ge=0, le=50)` to enforce API constraints (was default 25/max 100, now 10/50)
+- **Core search ordering** — `devrev_search_core` no longer applies re-ranking, preserving API ordering
+- **Namespace parsing resilience** — Handles whitespace, embedded quotes, and case variations from MCP Inspector
+
+### Changed
+- Search limit defaults changed from 25 → 10 (matches DevRev API default)
+- Search limit maximum changed from 100 → 50 (matches DevRev API constraint)
+
 ## [2.2.0] - 2026-02-09
 
 ### Added - DevRev MCP Server (Model Context Protocol)
@@ -386,6 +406,7 @@ This release marks the completion of all four development phases, providing a pr
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| 2.3.0 | 2026-02-11 | 🔍 Search SDK improvements & client-side re-ranking |
 | 2.2.0 | 2026-02-09 | 🤖 MCP Server - Full DevRev platform as AI-accessible tools |
 | 2.1.2 | 2026-01-28 | 🐛 Fix Work.applies_to_part parsing for API responses |
 | 2.1.1 | 2026-01-23 | 🐛 Fix RevUserState enum missing states |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "devrev-Python-SDK"
-version = "2.2.0"
+version = "2.3.0"
 description = "A modern, type-safe Python SDK for the DevRev API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/devrev_mcp/__init__.py
+++ b/src/devrev_mcp/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"


### PR DESCRIPTION
## Release v2.3.0 — Search SDK Improvements & Re-ranking

This PR bumps the version to 2.3.0 for the upcoming release.

### Changes
- Version bump in pyproject.toml, src/devrev_mcp/__init__.py, and Dockerfile
- Updated changelog with v2.3.0 release notes

### What's in this release

#### Added
- **Client-side re-ranking** for hybrid search — boosts results where query is a substring of display_name/title
- **Dynamic `_extract_display_name`** — supports all 35 DevRev namespace types for re-ranking
- **MCP Inspector compatibility** — `__main__.py` uses `parse_known_args()` to handle extra arguments

#### Fixed
- **SDK: SearchNamespace enum** — Expanded from 9 to 35 values matching all API-supported namespaces
- **SDK: Namespace serialization** — Fixed `namespaces` (plural) → `namespace` (singular) via `serialization_alias`
- **SDK: Namespace type** — Fixed from `list[SearchNamespace]` to single `SearchNamespace` value
- **SDK: SearchResult model** — Restructured with entity-specific dicts, added `modified_date` and `comments` fields
- **SDK: Limit validation** — Added `Field(ge=0, le=50)` to enforce API constraints (was default 25/max 100, now 10/50)
- **Core search ordering** — `devrev_search_core` no longer applies re-ranking, preserving API ordering
- **Namespace parsing resilience** — Handles whitespace, embedded quotes, and case variations from MCP Inspector

#### Changed
- Search limit defaults changed from 25 → 10 (matches DevRev API default)
- Search limit maximum changed from 100 → 50 (matches DevRev API constraint)

Related: PR #130, Issues #131, #132

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author