### PR TITLE
refactor: Migrate all enums from (str, Enum) to StrEnum (#138)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **SDK: Migrated all enums from `(str, Enum)` to `StrEnum`** — 32 enum classes across 21 files now use Python 3.11+ `StrEnum` instead of the legacy `(str, Enum)` pattern. This resolves ruff UP042 linting errors and aligns with modern Python best practices. Note: `str(EnumMember)` now returns the value string directly (e.g., `"active"`) instead of `"ClassName.MEMBER"`. (#138)
+
 ## [2.3.0] - 2026-02-11
 
 ### Added

--- a/src/devrev/config.py
+++ b/src/devrev/config.py
@@ -6,14 +6,14 @@ with optional .env file support for local development.
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Literal
 
 from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class APIVersion(str, Enum):
+class APIVersion(StrEnum):
     """DevRev API version selection.
 
     PUBLIC: Stable public API (default)

--- a/src/devrev/models/accounts.py
+++ b/src/devrev/models/accounts.py
@@ -6,7 +6,7 @@ This module contains Pydantic models for Account-related API operations.
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field
@@ -23,7 +23,7 @@ from devrev.models.base import (
 )
 
 
-class AccountTier(str, Enum):
+class AccountTier(StrEnum):
     """Account tier enumeration."""
 
     TIER1 = "tier-1"

--- a/src/devrev/models/articles.py
+++ b/src/devrev/models/articles.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
@@ -15,7 +15,7 @@ from devrev.models.base import (
 )
 
 
-class ArticleStatus(str, Enum):
+class ArticleStatus(StrEnum):
     """Article status enumeration."""
 
     DRAFT = "draft"

--- a/src/devrev/models/dev_users.py
+++ b/src/devrev/models/dev_users.py
@@ -7,7 +7,7 @@ Dev Users are internal organization users in DevRev.
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field
@@ -22,7 +22,7 @@ from devrev.models.base import (
 )
 
 
-class DevUserState(str, Enum):
+class DevUserState(StrEnum):
     """Dev user state enumeration."""
 
     ACTIVE = "active"
@@ -80,7 +80,7 @@ class DevUserExternalIdentityFilter(DevRevBaseModel):
     issuer: str | None = Field(default=None, description="Identity issuer")
 
 
-class DevUsersCreateRequestStateEnum(str, Enum):
+class DevUsersCreateRequestStateEnum(StrEnum):
     """Allowed states for Dev user creation."""
 
     SHADOW = "shadow"

--- a/src/devrev/models/engagements.py
+++ b/src/devrev/models/engagements.py
@@ -6,14 +6,14 @@ This module contains Pydantic models for Engagement-related API operations.
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
 from devrev.models.base import DevRevBaseModel, DevRevResponseModel, PaginatedResponse
 
 
-class EngagementType(str, Enum):
+class EngagementType(StrEnum):
     """Engagement type enumeration."""
 
     CALL = "call"

--- a/src/devrev/models/groups.py
+++ b/src/devrev/models/groups.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
@@ -16,7 +16,7 @@ from devrev.models.base import (
 )
 
 
-class GroupType(str, Enum):
+class GroupType(StrEnum):
     """Group type enumeration."""
 
     STATIC = "static"

--- a/src/devrev/models/incidents.py
+++ b/src/devrev/models/incidents.py
@@ -6,7 +6,7 @@ This module contains Pydantic models for Incident-related API operations.
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field
@@ -14,7 +14,7 @@ from pydantic import Field
 from devrev.models.base import DevRevBaseModel, DevRevResponseModel, PaginatedResponse
 
 
-class IncidentStage(str, Enum):
+class IncidentStage(StrEnum):
     """Incident stage enumeration (for request filters)."""
 
     ACKNOWLEDGED = "acknowledged"
@@ -23,7 +23,7 @@ class IncidentStage(str, Enum):
     RESOLVED = "resolved"
 
 
-class IncidentSeverity(str, Enum):
+class IncidentSeverity(StrEnum):
     """Incident severity enumeration (for request filters)."""
 
     SEV0 = "sev0"

--- a/src/devrev/models/links.py
+++ b/src/devrev/models/links.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field
@@ -16,7 +16,7 @@ from devrev.models.base import (
 )
 
 
-class LinkType(str, Enum):
+class LinkType(StrEnum):
     """Link type enumeration.
 
     Note: Additional link types may exist in the API. Unknown values

--- a/src/devrev/models/parts.py
+++ b/src/devrev/models/parts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
@@ -15,7 +15,7 @@ from devrev.models.base import (
 )
 
 
-class PartType(str, Enum):
+class PartType(StrEnum):
     """Part type enumeration."""
 
     PRODUCT = "product"

--- a/src/devrev/models/recommendations.py
+++ b/src/devrev/models/recommendations.py
@@ -5,14 +5,14 @@ This module contains Pydantic models for Recommendations-related API operations.
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
 from devrev.models.base import DevRevBaseModel, DevRevResponseModel
 
 
-class MessageRole(str, Enum):
+class MessageRole(StrEnum):
     """Message role enumeration."""
 
     SYSTEM = "system"

--- a/src/devrev/models/rev_users.py
+++ b/src/devrev/models/rev_users.py
@@ -7,7 +7,7 @@ Rev Users are external customer users in DevRev.
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field
@@ -23,7 +23,7 @@ from devrev.models.base import (
 )
 
 
-class RevUserState(str, Enum):
+class RevUserState(StrEnum):
     """Rev user state enumeration.
 
     Values match the DevRev API 'user-state' schema.

--- a/src/devrev/models/search.py
+++ b/src/devrev/models/search.py
@@ -5,7 +5,7 @@ This module contains Pydantic models for Search-related API operations.
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import ConfigDict, Field
@@ -13,7 +13,7 @@ from pydantic import ConfigDict, Field
 from devrev.models.base import DevRevBaseModel, DevRevResponseModel
 
 
-class SearchNamespace(str, Enum):
+class SearchNamespace(StrEnum):
     """Search namespace enumeration — 35 supported values."""
 
     ACCOUNT = "account"

--- a/src/devrev/models/slas.py
+++ b/src/devrev/models/slas.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
 from devrev.models.base import DevRevBaseModel, DevRevResponseModel, PaginatedResponse
 
 
-class SlaStatus(str, Enum):
+class SlaStatus(StrEnum):
     """SLA policy status enumeration."""
 
     DRAFT = "draft"
@@ -18,7 +18,7 @@ class SlaStatus(str, Enum):
     ARCHIVED = "archived"
 
 
-class SlaTrackerStatus(str, Enum):
+class SlaTrackerStatus(StrEnum):
     """SLA tracker status enumeration (for active SLA tracking)."""
 
     ACTIVE = "active"

--- a/src/devrev/models/sync.py
+++ b/src/devrev/models/sync.py
@@ -7,14 +7,14 @@ and staged object information used in external integrations.
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
 from devrev.models.base import DevRevBaseModel, DevRevResponseModel
 
 
-class SyncStatus(str, Enum):
+class SyncStatus(StrEnum):
     """Sync status enumeration."""
 
     PENDING = "pending"
@@ -24,7 +24,7 @@ class SyncStatus(str, Enum):
     SKIPPED = "skipped"
 
 
-class SyncDirection(str, Enum):
+class SyncDirection(StrEnum):
     """Sync direction enumeration."""
 
     INBOUND = "inbound"

--- a/src/devrev/models/tasks.py
+++ b/src/devrev/models/tasks.py
@@ -7,14 +7,14 @@ Tasks are a work item type used to track actionable items in DevRev.
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
 from devrev.models.base import DevRevBaseModel, DevRevResponseModel
 
 
-class TaskPriority(str, Enum):
+class TaskPriority(StrEnum):
     """Task priority level enumeration."""
 
     P0 = "p0"
@@ -23,7 +23,7 @@ class TaskPriority(str, Enum):
     P3 = "p3"
 
 
-class TaskStatus(str, Enum):
+class TaskStatus(StrEnum):
     """Task status enumeration."""
 
     OPEN = "open"

--- a/src/devrev/models/timeline_entries.py
+++ b/src/devrev/models/timeline_entries.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
@@ -15,7 +15,7 @@ from devrev.models.base import (
 )
 
 
-class TimelineEntryType(str, Enum):
+class TimelineEntryType(StrEnum):
     """Timeline entry type enumeration.
 
     Note: The API may return additional timeline entry types.

--- a/src/devrev/models/timeline_events.py
+++ b/src/devrev/models/timeline_events.py
@@ -7,7 +7,7 @@ which track changes and activities on DevRev objects over time.
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field
@@ -15,7 +15,7 @@ from pydantic import Field
 from devrev.models.base import DevRevBaseModel, DevRevResponseModel
 
 
-class TimelineEventType(str, Enum):
+class TimelineEventType(StrEnum):
     """Timeline event type enumeration."""
 
     CREATED = "created"

--- a/src/devrev/models/uoms.py
+++ b/src/devrev/models/uoms.py
@@ -6,7 +6,7 @@ This module contains Pydantic models for UOM-related API operations.
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field
@@ -14,7 +14,7 @@ from pydantic import Field
 from devrev.models.base import DevRevBaseModel, DevRevResponseModel, PaginatedResponse
 
 
-class UomAggregationType(str, Enum):
+class UomAggregationType(StrEnum):
     """UOM aggregation type enumeration."""
 
     SUM = "sum"
@@ -27,7 +27,7 @@ class UomAggregationType(str, Enum):
     OLDEST = "oldest"
 
 
-class UomMetricScope(str, Enum):
+class UomMetricScope(StrEnum):
     """UOM metric scope enumeration."""
 
     ORG = "org"

--- a/src/devrev/models/webhooks.py
+++ b/src/devrev/models/webhooks.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
@@ -15,7 +15,7 @@ from devrev.models.base import (
 )
 
 
-class WebhookStatus(str, Enum):
+class WebhookStatus(StrEnum):
     """Webhook status enumeration."""
 
     ACTIVE = "active"

--- a/src/devrev/models/widgets.py
+++ b/src/devrev/models/widgets.py
@@ -6,14 +6,14 @@ Widgets are used to display data visualizations on DevRev dashboards.
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
 from devrev.models.base import DevRevBaseModel, DevRevResponseModel
 
 
-class WidgetVisualizationType(str, Enum):
+class WidgetVisualizationType(StrEnum):
     """Widget visualization type enumeration."""
 
     BAR = "bar"
@@ -26,7 +26,7 @@ class WidgetVisualizationType(str, Enum):
     METRIC = "metric"
 
 
-class WidgetDataSourceType(str, Enum):
+class WidgetDataSourceType(StrEnum):
     """Widget data source type enumeration."""
 
     API = "api"
@@ -34,7 +34,7 @@ class WidgetDataSourceType(str, Enum):
     STATIC = "static"
 
 
-class WidgetAggregationType(str, Enum):
+class WidgetAggregationType(StrEnum):
     """Widget aggregation type enumeration."""
 
     COUNT = "count"

--- a/src/devrev/models/works.py
+++ b/src/devrev/models/works.py
@@ -7,7 +7,7 @@ Works include issues, tickets, tasks, and opportunities.
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field
@@ -27,7 +27,7 @@ from devrev.models.base import (
 from devrev.models.parts import PartSummary
 
 
-class WorkType(str, Enum):
+class WorkType(StrEnum):
     """Work item type enumeration."""
 
     ISSUE = "issue"
@@ -36,7 +36,7 @@ class WorkType(str, Enum):
     OPPORTUNITY = "opportunity"
 
 
-class IssuePriority(str, Enum):
+class IssuePriority(StrEnum):
     """Issue priority enumeration."""
 
     P0 = "p0"
@@ -45,7 +45,7 @@ class IssuePriority(str, Enum):
     P3 = "p3"
 
 
-class TicketSeverity(str, Enum):
+class TicketSeverity(StrEnum):
     """Ticket severity enumeration."""
 
     BLOCKER = "blocker"
@@ -54,7 +54,7 @@ class TicketSeverity(str, Enum):
     MEDIUM = "medium"
 
 
-class TicketChannels(str, Enum):
+class TicketChannels(StrEnum):
     """Ticket channel enumeration."""
 
     EMAIL = "email"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -239,7 +239,7 @@ class TestAPIVersion:
 
     def test_api_version_is_string_enum(self) -> None:
         """Test APIVersion can be used as string."""
-        assert str(APIVersion.PUBLIC) == "APIVersion.PUBLIC"
+        assert str(APIVersion.PUBLIC) == "public"
         assert APIVersion.PUBLIC == "public"
         assert APIVersion.BETA == "beta"
 


### PR DESCRIPTION
## Overview

Migrates all 32 enum classes across 21 files from the legacy `class Foo(str, Enum)` pattern to the modern `class Foo(StrEnum)` pattern available in Python 3.11+.

## Related Issues

- Fixes: #138 (CI: Migrate all enums from (str, Enum) to StrEnum)
- Related: PR #136 (where the CI failure was first observed)

## Root Cause

Ruff `0.15.x` graduated the `UP042` rule from preview to stable. Since the project's ruff config enables the `UP` (pyupgrade) rule set, CI now fails on all PRs with 32 `UP042` errors:
```
UP042 Class DevUserState inherits from both `str` and `enum.Enum`
help: Inherit from `enum.StrEnum`
```

## What Changed

### 21 source files (`src/devrev/`)
- Changed `from enum import Enum` → `from enum import StrEnum`
- Changed `class Foo(str, Enum):` → `class Foo(StrEnum):`
- **No functional changes** — `StrEnum` is functionally equivalent to `(str, Enum)`

### Affected enum classes (32 total)

| File | Enums |
|------|-------|
| `config.py` | `APIVersion` |
| `models/accounts.py` | `AccountTier` |
| `models/articles.py` | `ArticleStatus` |
| `models/dev_users.py` | `DevUserState`, `DevUsersCreateRequestStateEnum` |
| `models/engagements.py` | `EngagementType` |
| `models/groups.py` | `GroupType` |
| `models/incidents.py` | `IncidentStage`, `IncidentSeverity` |
| `models/links.py` | `LinkType` |
| `models/parts.py` | `PartType` |
| `models/recommendations.py` | `MessageRole` |
| `models/rev_users.py` | `RevUserState` |
| `models/search.py` | `SearchNamespace` |
| `models/slas.py` | `SlaStatus`, `SlaTrackerStatus` |
| `models/sync.py` | `SyncStatus`, `SyncDirection` |
| `models/tasks.py` | `TaskPriority`, `TaskStatus` |
| `models/timeline_entries.py` | `TimelineEntryType` |
| `models/timeline_events.py` | `TimelineEventType` |
| `models/uoms.py` | `UomAggregationType`, `UomMetricScope` |
| `models/webhooks.py` | `WebhookStatus` |
| `models/widgets.py` | `WidgetVisualizationType`, `WidgetDataSourceType`, `WidgetAggregationType` |
| `models/works.py` | `WorkType`, `IssuePriority`, `TicketSeverity`, `TicketChannels` |

### Test update
- `tests/unit/test_config.py`: Updated `test_api_version_is_string_enum` assertion — `str(StrEnum.VALUE)` returns the value directly (`"public"`) instead of `"APIVersion.PUBLIC"`

### Changelog
- Added entry under `[Unreleased]` documenting the migration

## Testing

- ✅ All 695 unit tests pass
- ✅ `ruff check src/` — 0 errors
- ✅ `ruff format --check src/` — all 106 files formatted
- ✅ No `UP042` errors remain

## Deployment Notes

- **No breaking changes** for consumers — `StrEnum` values behave identically to `(str, Enum)` values
- **Requires Python 3.11+** — already the project's minimum target
- One behavioral difference: `str(SomeEnum.VALUE)` now returns the value string directly instead of `"ClassName.MEMBER"`. This is the correct modern behavior.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author