### PR TITLE
chore(deps): Consolidate Dependabot dependency updates (March 2026)

### DIFF
--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Upload report
         if: steps.detect.outputs.has_changes == 'true'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: api-change-report
           path: api_change_report.md

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Configure Docker for Artifact Registry
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: uv sync --frozen --all-extras
@@ -77,7 +77,7 @@ jobs:
           python -c "import devrev; print(f'Installed: devrev')"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
## Summary

Consolidates 3 Dependabot PRs into a single update for cleaner merge history.

### Dependencies Updated

| Dependency | From | To | Workflow Files |
|------------|------|----|---------|
| `google-github-actions/setup-gcloud` | v2 | v3 | `deploy.yml` |
| `astral-sh/setup-uv` | v4 | v7 | `docs.yml`, `release.yml` |
| `actions/upload-artifact` | v6 | v7 | `release.yml`, `api-check.yml` |

### Supersedes
- #179
- #180
- #181

These PRs will be closed after this is merged.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author