### PR TITLE
fix: Add owned_by, parent_part, and tags to devrev_parts_create

### DIFF
--- a/src/devrev/models/parts.py
+++ b/src/devrev/models/parts.py
@@ -53,11 +53,26 @@ class PartSummary(DevRevResponseModel):
 
 
 class PartsCreateRequest(DevRevBaseModel):
-    """Request to create a part."""
+    """Request to create a part.
+
+    For non-product parts (capability, feature, enhancement), the parent_part
+    parameter is required to specify the parent part in the hierarchy.
+    """
 
     name: str = Field(..., description="Part name")
     type: PartType = Field(..., description="Part type")
     description: str | None = Field(default=None, description="Description")
+    owned_by: list[str] | None = Field(
+        default=None,
+        description="List of owner user IDs (e.g., ['DEVU-4'] or full DON IDs)",
+    )
+    parent_part: list[str] | None = Field(
+        default=None,
+        description="Parent part ID (required for capability/feature/enhancement). "
+        "Array with at most 1 element.",
+        max_length=1,
+    )
+    tags: list[str] | None = Field(default=None, description="List of tag IDs")
 
 
 class PartsGetRequest(DevRevBaseModel):

--- a/src/devrev_mcp/tools/parts.py
+++ b/src/devrev_mcp/tools/parts.py
@@ -87,6 +87,9 @@ if _config.enable_destructive_tools:
         name: str,
         type: str,
         description: str | None = None,
+        owned_by: list[str] | None = None,
+        parent_part: list[str] | None = None,
+        tags: list[str] | None = None,
     ) -> dict[str, Any]:
         """Create a new DevRev part.
 
@@ -94,6 +97,10 @@ if _config.enable_destructive_tools:
             name: The name of the part.
             type: The type of part (PRODUCT, CAPABILITY, FEATURE, ENHANCEMENT).
             description: Optional description of the part.
+            owned_by: List of owner user IDs (e.g., ["DEVU-4"] or full DON IDs).
+            parent_part: Parent part ID (required for capability/feature/enhancement).
+                Array with at most 1 element.
+            tags: List of tag IDs to associate with the part.
 
         Returns:
             Dictionary containing the created part details.
@@ -114,6 +121,9 @@ if _config.enable_destructive_tools:
                 name=name,
                 type=part_type,
                 description=description,
+                owned_by=owned_by,
+                parent_part=parent_part,
+                tags=tags,
             )
             part = await app.get_client().parts.create(request)
             return serialize_model(part)

--- a/tests/unit/mcp/test_tools_parts.py
+++ b/tests/unit/mcp/test_tools_parts.py
@@ -156,6 +156,85 @@ class TestPartsCreateTool:
         call_args = mock_client.parts.create.call_args[0][0]
         assert call_args.type == PartType.FEATURE
 
+    @pytest.mark.asyncio
+    async def test_create_with_owned_by(self, mock_ctx, mock_client):
+        """Test creating a part with owned_by parameter."""
+        mock_part = _make_mock_part(id="PROD-100", name="Owned Product")
+        mock_client.parts.create.return_value = mock_part
+
+        result = await devrev_parts_create(
+            mock_ctx,
+            name="Owned Product",
+            type="product",
+            owned_by=["DEVU-4", "don:identity:dvrv-us-1:devo/1:devu/5"],
+        )
+
+        assert result["id"] == "PROD-100"
+        call_args = mock_client.parts.create.call_args[0][0]
+        assert call_args.owned_by == ["DEVU-4", "don:identity:dvrv-us-1:devo/1:devu/5"]
+
+    @pytest.mark.asyncio
+    async def test_create_with_parent_part(self, mock_ctx, mock_client):
+        """Test creating a feature with parent_part parameter."""
+        mock_part = _make_mock_part(id="FEAT-200", name="Child Feature", type="feature")
+        mock_client.parts.create.return_value = mock_part
+
+        result = await devrev_parts_create(
+            mock_ctx,
+            name="Child Feature",
+            type="feature",
+            parent_part=["don:core:dvrv-us-1:devo/1:part/1"],
+            owned_by=["DEVU-4"],
+        )
+
+        assert result["id"] == "FEAT-200"
+        call_args = mock_client.parts.create.call_args[0][0]
+        assert call_args.parent_part == ["don:core:dvrv-us-1:devo/1:part/1"]
+        assert call_args.type == PartType.FEATURE
+
+    @pytest.mark.asyncio
+    async def test_create_with_tags(self, mock_ctx, mock_client):
+        """Test creating a part with tags parameter."""
+        mock_part = _make_mock_part(id="CAP-300", name="Tagged Capability", type="capability")
+        mock_client.parts.create.return_value = mock_part
+
+        result = await devrev_parts_create(
+            mock_ctx,
+            name="Tagged Capability",
+            type="capability",
+            parent_part=["don:core:dvrv-us-1:devo/1:part/1"],
+            tags=["tag-1", "tag-2"],
+        )
+
+        assert result["id"] == "CAP-300"
+        call_args = mock_client.parts.create.call_args[0][0]
+        assert call_args.tags == ["tag-1", "tag-2"]
+
+    @pytest.mark.asyncio
+    async def test_create_with_all_optional_params(self, mock_ctx, mock_client):
+        """Test creating a part with all optional parameters."""
+        mock_part = _make_mock_part(id="ENH-400", name="Full Enhancement", type="enhancement")
+        mock_client.parts.create.return_value = mock_part
+
+        result = await devrev_parts_create(
+            mock_ctx,
+            name="Full Enhancement",
+            type="enhancement",
+            description="A complete enhancement",
+            owned_by=["DEVU-1"],
+            parent_part=["FEAT-100"],
+            tags=["enhancement-tag"],
+        )
+
+        assert result["id"] == "ENH-400"
+        call_args = mock_client.parts.create.call_args[0][0]
+        assert call_args.name == "Full Enhancement"
+        assert call_args.type == PartType.ENHANCEMENT
+        assert call_args.description == "A complete enhancement"
+        assert call_args.owned_by == ["DEVU-1"]
+        assert call_args.parent_part == ["FEAT-100"]
+        assert call_args.tags == ["enhancement-tag"]
+
 
 class TestPartsUpdateTool:
     """Tests for devrev_parts_update tool."""


### PR DESCRIPTION
## Summary

Fixes #158

The `devrev_parts_create` MCP tool was failing with "Validation error: Bad Request" because it was missing required parameters needed by the DevRev API to create parts.

## Changes

### SDK Layer (`src/devrev/models/parts.py`)
- Added `owned_by: list[str] | None` field to `PartsCreateRequest`
- Added `parent_part: list[str] | None` field to `PartsCreateRequest`
- Added `tags: list[str] | None` field to `PartsCreateRequest`
- Added docstring explaining parent_part requirement for non-product parts

### MCP Tool (`src/devrev_mcp/tools/parts.py`)
- Added `owned_by` parameter to `devrev_parts_create` function
- Added `parent_part` parameter to `devrev_parts_create` function
- Added `tags` parameter to `devrev_parts_create` function
- Updated docstring with parameter descriptions
- Passed new parameters through to `PartsCreateRequest`

### Tests (`tests/unit/mcp/test_tools_parts.py`)
- Added `test_create_with_owned_by` - tests creating a part with owner IDs
- Added `test_create_with_parent_part` - tests creating a feature with parent part
- Added `test_create_with_tags` - tests creating a part with tags
- Added `test_create_with_all_optional_params` - tests all parameters together

## Testing

- All 16 parts tests pass: `pytest tests/unit/mcp/test_tools_parts.py -v`
- Full test suite passes: 971 tests pass
- Linting passes: `ruff check .` and `ruff format --check .`

## API Reference

Per the [DevRev API documentation](https://developer.devrev.ai/api-reference/parts/create):

| Parameter | Required | Description |
|-----------|----------|-------------|
| `type` | Yes | `product`, `capability`, `feature`, `enhancement` |
| `name` | Yes | Name of the part |
| `owned_by` | Effectively yes | Array of user IDs |
| `parent_part` | Yes for non-products | Array with parent part ID (max 1) |
| `description` | No | Description text |
| `tags` | No | Tags array |

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author