### PR TITLE
feat: Expose shared_with field through MCP article tools

### DIFF
--- a/src/devrev/models/articles.py
+++ b/src/devrev/models/articles.py
@@ -328,6 +328,14 @@ class ArticlesUpdateRequestTags(DevRevBaseModel):
     set: list[SetTagWithValue] | None = Field(default=None, description="Set tags")
 
 
+class ArticlesUpdateRequestSharedWith(DevRevBaseModel):
+    """Shared-with update for articles."""
+
+    set: list[SetSharedWithMembership] | None = Field(
+        default=None, description="Set shared-with memberships"
+    )
+
+
 class ArticlesUpdateRequest(DevRevBaseModel):
     """Request to update an article."""
 
@@ -364,6 +372,9 @@ class ArticlesUpdateRequest(DevRevBaseModel):
     resource: dict[str, Any] | None = Field(
         default=None,
         description="Resource configuration (read-only on updates, use artifacts instead)",
+    )
+    shared_with: ArticlesUpdateRequestSharedWith | None = Field(
+        default=None, description="New shared-with memberships"
     )
     tags: ArticlesUpdateRequestTags | None = Field(default=None, description="New tags")
     url: str | None = Field(default=None, description="Article URL")

--- a/src/devrev/services/articles.py
+++ b/src/devrev/services/articles.py
@@ -23,10 +23,12 @@ from devrev.models.articles import (
     ArticleStatus,
     ArticlesUpdateRequest,
     ArticlesUpdateRequestAppliesToParts,
+    ArticlesUpdateRequestSharedWith,
     ArticlesUpdateRequestTags,
     ArticlesUpdateResponse,
     ArticleType,
     ArticleWithContent,
+    SetSharedWithMembership,
 )
 from devrev.models.artifacts import (
     ArtifactPrepareRequest,
@@ -205,6 +207,7 @@ class ArticlesService(BaseService):
         article_type: str | None = None,
         language: str | None = None,
         authored_by: builtins.list[str] | None = None,
+        shared_with: builtins.list[SetSharedWithMembership] | None = None,
     ) -> Article:
         """Create an article with content in a single operation.
 
@@ -230,6 +233,7 @@ class ArticlesService(BaseService):
             article_type: Optional article type ('article', 'page', 'content_block')
             language: Optional language code (e.g., 'en')
             authored_by: Optional list of user IDs who author the article
+            shared_with: Optional list of shared-with memberships
 
         Returns:
             Created article
@@ -292,6 +296,7 @@ class ArticlesService(BaseService):
                 article_type=article_type,
                 language=language,
                 authored_by=authored_by,
+                shared_with=shared_with,
             )
             return self.create(article_req)
 
@@ -454,6 +459,7 @@ class ArticlesService(BaseService):
         access_level: ArticleAccessLevel | None = None,
         tags: builtins.list[SetTagWithValue] | None = None,
         language: str | None = None,
+        shared_with: builtins.list[SetSharedWithMembership] | None = None,
     ) -> Article:
         """Update article metadata and/or content.
 
@@ -472,6 +478,7 @@ class ArticlesService(BaseService):
             access_level: Optional access level (internal, external, private, public)
             tags: Optional list of tags to apply (list of SetTagWithValue objects)
             language: Optional language code (e.g., 'en')
+            shared_with: Optional list of shared-with memberships
 
         Returns:
             Updated article
@@ -532,6 +539,11 @@ class ArticlesService(BaseService):
         if tags is not None:
             tags_req = ArticlesUpdateRequestTags(set=tags)
 
+        # Build shared_with wrapper if provided
+        shared_with_req = None
+        if shared_with is not None:
+            shared_with_req = ArticlesUpdateRequestSharedWith(set=shared_with)
+
         # Update metadata if any metadata fields provided
         has_metadata = (
             title is not None
@@ -541,6 +553,7 @@ class ArticlesService(BaseService):
             or access_level is not None
             or tags is not None
             or language is not None
+            or shared_with is not None
         )
         if has_metadata:
             update_req = ArticlesUpdateRequest(
@@ -552,6 +565,7 @@ class ArticlesService(BaseService):
                 access_level=access_level,
                 tags=tags_req,
                 language=language,
+                shared_with=shared_with_req,
             )
             return self.update(update_req)
 
@@ -665,6 +679,7 @@ class AsyncArticlesService(AsyncBaseService):
         article_type: str | None = None,
         language: str | None = None,
         authored_by: builtins.list[str] | None = None,
+        shared_with: builtins.list[SetSharedWithMembership] | None = None,
     ) -> Article:
         """Create an article with content in a single operation (async).
 
@@ -690,6 +705,7 @@ class AsyncArticlesService(AsyncBaseService):
             article_type: Optional article type ('article', 'page', 'content_block')
             language: Optional language code (e.g., 'en')
             authored_by: Optional list of user IDs who author the article
+            shared_with: Optional list of shared-with memberships
 
         Returns:
             Created article
@@ -740,6 +756,7 @@ class AsyncArticlesService(AsyncBaseService):
                 article_type=article_type,
                 language=language,
                 authored_by=authored_by,
+                shared_with=shared_with,
             )
             return await self.create(article_req)
 
@@ -891,6 +908,7 @@ class AsyncArticlesService(AsyncBaseService):
         access_level: ArticleAccessLevel | None = None,
         tags: builtins.list[SetTagWithValue] | None = None,
         language: str | None = None,
+        shared_with: builtins.list[SetSharedWithMembership] | None = None,
     ) -> Article:
         """Update article metadata and/or content (async).
 
@@ -909,6 +927,7 @@ class AsyncArticlesService(AsyncBaseService):
             access_level: Optional access level (internal, external, private, public)
             tags: Optional list of tags to apply (list of SetTagWithValue objects)
             language: Optional language code (e.g., 'en')
+            shared_with: Optional list of shared-with memberships
 
         Returns:
             Updated article
@@ -936,6 +955,11 @@ class AsyncArticlesService(AsyncBaseService):
         if tags is not None:
             tags_req = ArticlesUpdateRequestTags(set=tags)
 
+        # Build shared_with wrapper if provided
+        shared_with_req = None
+        if shared_with is not None:
+            shared_with_req = ArticlesUpdateRequestSharedWith(set=shared_with)
+
         # Update metadata if any metadata fields provided
         has_metadata = (
             title is not None
@@ -945,6 +969,7 @@ class AsyncArticlesService(AsyncBaseService):
             or access_level is not None
             or tags is not None
             or language is not None
+            or shared_with is not None
         )
         if has_metadata:
             update_req = ArticlesUpdateRequest(
@@ -956,6 +981,7 @@ class AsyncArticlesService(AsyncBaseService):
                 access_level=access_level,
                 tags=tags_req,
                 language=language,
+                shared_with=shared_with_req,
             )
             return await self.update(update_req)
 

--- a/src/devrev_mcp/tools/articles.py
+++ b/src/devrev_mcp/tools/articles.py
@@ -17,6 +17,7 @@ from devrev.models.articles import (
     ArticlesGetRequest,
     ArticlesListRequest,
     ArticleStatus,
+    SetSharedWithMembership,
 )
 from devrev.models.base import SetTagWithValue
 from devrev_mcp.server import _config, mcp
@@ -111,6 +112,7 @@ if _config.enable_destructive_tools:
         tags: list[str] | None = None,
         language: str | None = None,
         authored_by: list[str] | None = None,
+        shared_with: list[dict[str, str]] | None = None,
     ) -> dict[str, Any]:
         """Create a new article with content.
 
@@ -129,6 +131,8 @@ if _config.enable_destructive_tools:
             tags: Optional list of tag IDs to apply to the article.
             language: Optional language code (e.g., 'en').
             authored_by: Optional list of user IDs who author the article.
+            shared_with: Optional list of shared-with memberships. Each entry is
+                a dict with 'member' (required user/group ID) and optional 'role'.
 
         Returns:
             Dictionary containing the created article details.
@@ -164,6 +168,13 @@ if _config.enable_destructive_tools:
                 [SetTagWithValue(id=tag_id) for tag_id in tags] if tags is not None else None
             )
 
+            # Convert shared_with dicts to SetSharedWithMembership objects
+            shared_with_list = (
+                [SetSharedWithMembership(**entry) for entry in shared_with]
+                if shared_with is not None
+                else None
+            )
+
             article = await app.get_client().articles.create_with_content(
                 title=title,
                 content=content,
@@ -177,6 +188,7 @@ if _config.enable_destructive_tools:
                 tags=tags_list,
                 language=language,
                 authored_by=authored_by,
+                shared_with=shared_with_list,
             )
             return serialize_model(article)
         except DevRevError as e:
@@ -194,6 +206,7 @@ if _config.enable_destructive_tools:
         access_level: str | None = None,
         tags: list[str] | None = None,
         language: str | None = None,
+        shared_with: list[dict[str, str]] | None = None,
     ) -> dict[str, Any]:
         """Update an existing article in DevRev.
 
@@ -213,6 +226,8 @@ if _config.enable_destructive_tools:
             tags: Optional list of tag IDs to apply to the article.
                 Pass an empty list to remove all tags.
             language: Optional language code (e.g., 'en').
+            shared_with: Optional list of shared-with memberships. Each entry is
+                a dict with 'member' (required user/group ID) and optional 'role'.
 
         Returns:
             Dictionary containing the updated article details.
@@ -248,6 +263,13 @@ if _config.enable_destructive_tools:
                 [SetTagWithValue(id=tag_id) for tag_id in tags] if tags is not None else None
             )
 
+            # Convert shared_with dicts to SetSharedWithMembership objects
+            shared_with_list = (
+                [SetSharedWithMembership(**entry) for entry in shared_with]
+                if shared_with is not None
+                else None
+            )
+
             article = await app.get_client().articles.update_with_content(
                 id=id,
                 title=title,
@@ -258,6 +280,7 @@ if _config.enable_destructive_tools:
                 access_level=article_access_level,
                 tags=tags_list,
                 language=language,
+                shared_with=shared_with_list,
             )
             return serialize_model(article)
         except DevRevError as e:

--- a/tests/unit/mcp/test_tools_articles.py
+++ b/tests/unit/mcp/test_tools_articles.py
@@ -388,6 +388,48 @@ class TestArticlesUpdateTool:
         assert tags_arg == []
 
     @pytest.mark.asyncio
+    async def test_update_with_shared_with(self, mock_ctx, mock_client):
+        """Test updating an article with shared_with memberships."""
+        mock_article = _make_mock_article(
+            id="article-1",
+            title="Shared Article",
+            status="published",
+        )
+        mock_client.articles.update_with_content.return_value = mock_article
+
+        result = await devrev_articles_update(
+            mock_ctx,
+            id="article-1",
+            shared_with=[
+                {"member": "don:identity:dvrv-us-1:devo/1:devu/100", "role": "editor"},
+            ],
+        )
+
+        assert result["title"] == "Shared Article"
+        # Verify shared_with was converted and passed to SDK
+        call_args = mock_client.articles.update_with_content.call_args
+        shared_arg = call_args[1]["shared_with"]
+        assert shared_arg is not None
+        assert len(shared_arg) == 1
+        assert shared_arg[0].member == "don:identity:dvrv-us-1:devo/1:devu/100"
+        assert shared_arg[0].role == "editor"
+
+    @pytest.mark.asyncio
+    async def test_update_without_shared_with(self, mock_ctx, mock_client):
+        """Test updating an article without shared_with passes None."""
+        mock_article = _make_mock_article(id="article-1", title="Article")
+        mock_client.articles.update_with_content.return_value = mock_article
+
+        await devrev_articles_update(
+            mock_ctx,
+            id="article-1",
+            title="Article",
+        )
+
+        call_args = mock_client.articles.update_with_content.call_args
+        assert call_args[1]["shared_with"] is None
+
+    @pytest.mark.asyncio
     async def test_create_with_empty_tags(self, mock_ctx, mock_client):
         """Test creating with empty tags list passes empty list (not None)."""
         mock_article = _make_mock_article(
@@ -410,6 +452,53 @@ class TestArticlesUpdateTool:
         tags_arg = call_args[1]["tags"]
         assert tags_arg is not None
         assert tags_arg == []
+
+    @pytest.mark.asyncio
+    async def test_create_with_shared_with(self, mock_ctx, mock_client):
+        """Test creating an article with shared_with memberships."""
+        mock_article = _make_mock_article(
+            title="Shared Article",
+            description="Content shared with users",
+        )
+        mock_client.articles.create_with_content.return_value = mock_article
+
+        result = await devrev_articles_create(
+            mock_ctx,
+            title="Shared Article",
+            content="Content shared with users",
+            owned_by=["don:identity:dvrv-us-1:devo/test:devu/1"],
+            shared_with=[
+                {"member": "don:identity:dvrv-us-1:devo/1:devu/100", "role": "viewer"},
+                {"member": "don:identity:dvrv-us-1:devo/1:devu/200"},
+            ],
+        )
+
+        assert result["title"] == "Shared Article"
+        # Verify shared_with was converted and passed to SDK
+        call_args = mock_client.articles.create_with_content.call_args
+        shared_arg = call_args[1]["shared_with"]
+        assert shared_arg is not None
+        assert len(shared_arg) == 2
+        assert shared_arg[0].member == "don:identity:dvrv-us-1:devo/1:devu/100"
+        assert shared_arg[0].role == "viewer"
+        assert shared_arg[1].member == "don:identity:dvrv-us-1:devo/1:devu/200"
+        assert shared_arg[1].role is None
+
+    @pytest.mark.asyncio
+    async def test_create_without_shared_with(self, mock_ctx, mock_client):
+        """Test creating an article without shared_with passes None."""
+        mock_article = _make_mock_article(title="Normal Article", description="Content")
+        mock_client.articles.create_with_content.return_value = mock_article
+
+        await devrev_articles_create(
+            mock_ctx,
+            title="Normal Article",
+            content="Content",
+            owned_by=["don:identity:dvrv-us-1:devo/test:devu/1"],
+        )
+
+        call_args = mock_client.articles.create_with_content.call_args
+        assert call_args[1]["shared_with"] is None
 
 
 class TestArticlesDeleteTool:


### PR DESCRIPTION
## Overview

Exposes the `shared_with` field through the `devrev_articles_create` and `devrev_articles_update` MCP tools, enabling AI agents to control article sharing with specific users/groups.

## Related Issues

- Implements: #188
- Origin: PR #186 code review (LOW priority suggestion)

## Changes

### Model (`src/devrev/models/articles.py`)
- Added `ArticlesUpdateRequestSharedWith` wrapper model (follows existing set-wrapper pattern)
- Added `shared_with` field to `ArticlesUpdateRequest`

### Service (`src/devrev/services/articles.py`)
- Added `shared_with` parameter to `create_with_content()` (sync + async)
- Added `shared_with` parameter to `update_with_content()` (sync + async)
- Builds `ArticlesUpdateRequestSharedWith` wrapper for update requests

### MCP Tools (`src/devrev_mcp/tools/articles.py`)
- Added `shared_with: list[dict[str, str]] | None` parameter to `devrev_articles_create`
- Added `shared_with: list[dict[str, str]] | None` parameter to `devrev_articles_update`
- Converts dict entries to `SetSharedWithMembership` objects before passing to SDK
- Each entry accepts `member` (required) and `role` (optional)

### Tests (`tests/unit/mcp/test_tools_articles.py`)
- Added 4 new tests:
  - `test_create_with_shared_with` — verifies conversion and passing of memberships
  - `test_create_without_shared_with` — verifies None is passed when omitted
  - `test_update_with_shared_with` — verifies conversion for update path
  - `test_update_without_shared_with` — verifies None is passed when omitted

## Testing

- All 989 unit tests pass
- ruff check clean
- No regressions

## Usage Example

```python
# Create article shared with specific users
result = await devrev_articles_create(
    ctx,
    title="Shared Guide",
    content="<h1>Guide</h1>",
    owned_by=["DEVU-1"],
    shared_with=[
        {"member": "don:identity:dvrv-us-1:devo/1:devu/100", "role": "viewer"},
        {"member": "don:identity:dvrv-us-1:devo/1:devu/200"},
    ],
)
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author