### PR TITLE
chore(deps): Bump pytest from 8.4.2 to 9.0.3 (CUSS-409)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Bump pytest from 8.4.2 to 9.0.3** (CUSS-409) — Major version upgrade including security fix CVE-2025-71176 (insecure temporary directory). All 1,091 tests pass without modification.
+
 ## [2.14.0] - 2026-04-14
 
 ### Added

--- a/uv.lock
+++ b/uv.lock
@@ -1550,7 +1550,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1559,9 +1559,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Upgrade pytest from **8.4.2** → **9.0.3** (major version bump).

**Linear Issue:** [CUSS-409](https://linear.app/augmentcode/issue/CUSS-409)
**Replaces:** Dependabot PR #211

## Why

- **Security fix** — CVE-2025-71176: insecure temporary directory usage
- **Bug fixes** — `pytest.approx` mapping order, exceptiongroup `__tracebackhide__` crash, `subTest()` non-string messages
- **Breaking changes** — Terminal progress feature (disabled by default on non-Windows), `config.inicfg` compatibility shim

## What Changed

- `uv.lock` — pytest 8.4.2 → 9.0.3
- `docs/changelog.md` — Added security entry under [Unreleased]

## Testing

- ✅ All **1,091 unit tests pass** without any modifications
- ✅ Ruff lint clean
- ✅ Ruff format clean
- No test code changes required for pytest 9.x compatibility

## Notes

- The `pyproject.toml` constraint `pytest>=7.4.0,<10.0.0` already covers 9.x — no constraint changes needed
- pytest 9.0.0 breaking changes (`config.inicfg`, terminal progress) do not affect this project
- This supersedes Dependabot PR #211 which was based on a stale main branch