### PR TITLE
feat: date-based listing helpers for works and conversations (CUSS-451)

### DIFF
--- a/docs/api/services/conversations.md
+++ b/docs/api/services/conversations.md
@@ -35,3 +35,50 @@ response = client.conversations.get(id="don:core:dvrv-us-1:devo/1:conversation/1
 print(f"Title: {response.conversation.title}")
 ```
 
+### Sort Order
+
+`list` accepts a `sort_by` parameter. Both forms are accepted and normalized
+to the server form before the request is sent:
+
+- Canonical: `"modified_date:desc"`, `"created_date:asc"`
+- Legacy shortcut: `"-modified_date"` (descending), `"created_date"` (ascending)
+
+!!! note "Server requires `field:direction`"
+    The DevRev server rejects bare `"-field"` entries. The SDK normalizes
+    legacy shortcuts to the `field:direction` form on your behalf.
+
+### List Conversations Modified Since
+
+Use `list_modified_since` to stream conversations that changed within a recent
+window. It pages server-side sorted `modified_date:desc` and stops as soon as
+a record older than the cutoff is seen.
+
+```python
+from datetime import datetime, timedelta, timezone
+from devrev import DevRevClient
+
+client = DevRevClient()
+
+cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+recent = client.conversations.list_modified_since(cutoff, limit=200)
+for conv in recent:
+    print(f"{conv.id}: {conv.title}")
+```
+
+### Async Usage
+
+```python
+import asyncio
+from datetime import datetime, timedelta, timezone
+from devrev import AsyncDevRevClient
+
+async def main():
+    async with AsyncDevRevClient() as client:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=1)
+        recent = await client.conversations.list_modified_since(cutoff)
+        for conv in recent:
+            print(f"{conv.id}: {conv.title}")
+
+asyncio.run(main())
+```
+

--- a/docs/api/services/works.md
+++ b/docs/api/services/works.md
@@ -2,6 +2,9 @@
 
 Manage work items (issues, tickets, tasks, opportunities) in DevRev.
 
+In DevRev, **works** is the umbrella type covering tickets (customer support),
+issues (engineering), and tasks.
+
 ## WorksService
 
 ::: devrev.services.works.WorksService
@@ -15,6 +18,8 @@ Manage work items (issues, tickets, tasks, opportunities) in DevRev.
         - delete
         - export
         - count
+        - list_modified_since
+        - list_created_since
 
 ## AsyncWorksService
 
@@ -121,6 +126,65 @@ response = client.works.export(
 print(f"Exported {len(response.works)} issues")
 ```
 
+### Sort Order
+
+`list` and `export` accept a `sort_by` parameter. Both forms are accepted and
+normalized to the server form before the request is sent:
+
+- Canonical: `"modified_date:desc"`, `"created_date:asc"`
+- Legacy shortcut: `"-modified_date"` (descending), `"created_date"` (ascending)
+
+```python
+# Canonical form
+response = client.works.list(
+    type=[WorkType.TICKET],
+    sort_by=["modified_date:desc"],
+)
+
+# Legacy shortcut — normalized internally to "modified_date:desc"
+response = client.works.list(
+    type=[WorkType.TICKET],
+    sort_by=["-modified_date"],
+)
+```
+
+!!! note "Server requires `field:direction`"
+    The DevRev server rejects bare `"-field"` entries. The SDK normalizes
+    legacy shortcuts to the `field:direction` form on your behalf — you do not
+    need to change existing call sites, but new code should prefer the
+    canonical form.
+
+### List Work Items Modified or Created Since
+
+Use `list_modified_since` / `list_created_since` to stream work items that
+changed within a recent window. Both helpers page server-side sorted
+`{timestamp_field}:desc` and early-exit as soon as a record older than the
+cutoff is seen.
+
+```python
+from datetime import datetime, timedelta, timezone
+from devrev import DevRevClient
+from devrev.models import WorkType
+
+client = DevRevClient()
+
+cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+
+# All works modified in the last 7 days
+recent = client.works.list_modified_since(
+    cutoff,
+    type=[WorkType.TICKET, WorkType.ISSUE],
+)
+
+# Cap total items; page_size tunes per-request page size
+recent_capped = client.works.list_created_since(
+    cutoff,
+    type=[WorkType.TICKET],
+    limit=500,
+    page_size=100,
+)
+```
+
 ### Async Usage
 
 ```python
@@ -132,6 +196,10 @@ async def main():
         response = await client.works.list(limit=10)
         for work in response.works:
             print(f"[{work.type}] {work.title}")
+
+        # Async variants of the time-based helpers
+        cutoff = datetime.now(timezone.utc) - timedelta(days=1)
+        recent = await client.works.list_modified_since(cutoff)
 
 asyncio.run(main())
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`WorksService.list_modified_since` and `list_created_since`** (CUSS-451) —
+  New sync and async helpers on `WorksService` / `AsyncWorksService` that
+  stream work items with `modified_date >= after` or `created_date >= after`.
+  Both page server-side sorted `{timestamp_field}:desc` and early-exit when a
+  record older than the cutoff is seen. Accept `type`, `owned_by`,
+  `applies_to_part`, `limit` (hard cap on total items), and `page_size`
+  (per-request page size).
+- **`ConversationsService.list_modified_since`** (CUSS-451) — New sync and
+  async helper that streams conversations modified after a given datetime,
+  newest first. Pages via cursor until the server returns no further cursor,
+  `limit` is reached, or a conversation older than `after` is seen. Accepts
+  `limit` and `page_size`.
+- **MCP tools for time-windowed queries** (CUSS-451) —
+  `devrev_works_list_modified_since`, `devrev_works_list_created_since`, and
+  `devrev_conversations_list_modified_since`. Each accepts an ISO-8601
+  `after` timestamp and optional `limit`.
+- **`sort_by` and `modified_date_after` / `modified_date_before` on
+  `devrev_conversations_list` MCP tool** (CUSS-451) — Expose the same sort
+  and date-range filters already available in the SDK `list` request.
+- **`sort_by` on `devrev_works_list` and `devrev_works_export` MCP tools**
+  (CUSS-451) — Forward the sort order down to the SDK.
+
+### Changed / Breaking
+
+- **`sort_by` syntax normalization** (CUSS-451) — The DevRev server rejects
+  bare `"-field"` entries on `/works.list` and `/conversations.list` and
+  requires the canonical `"field:asc"` / `"field:desc"` form. `WorksService`
+  and `ConversationsService` now normalize both legacy `"-field"` /
+  `"field"` shortcuts and canonical `"field:direction"` entries to the
+  server form before sending the request. Existing call sites using the
+  `"-field"` shortcut continue to work unchanged; new code should prefer the
+  canonical form. Callers that previously sent `"-field"` directly to a
+  request model and bypassed the service layer will now see their input
+  normalized when they route through `WorksService.list` /
+  `ConversationsService.list`.
+
+### Fixed
+
+- **`/works.list` rejected bare `"-field"` sort entries** (CUSS-451) —
+  Integration tests observed the DevRev PUBLIC API returning an error for
+  bare `"-modified_date"` / `"-created_date"` sort values, requiring the
+  canonical `field:direction` form. `WorksService.list` /
+  `WorksService.export` (and their async variants) now normalize
+  `sort_by` before sending.
+- **`/conversations.list` rejected bare `"-field"` sort entries** (CUSS-451)
+  — Same server behavior observed for conversations. `ConversationsService.list`
+  (and its async variant) now normalize `sort_by` before sending.
+- **`list_modified_since` / `list_created_since` helpers paginate until the
+  cutoff is crossed** (CUSS-451) — Server-side `modified_date` / `created_date`
+  filters may not be honored uniformly across older accounts. The new
+  helpers apply client-side early-exit on the sorted stream so results are
+  bounded by the cutoff even when the server does not filter.
+
 ## [2.14.1] - 2026-04-14
 
 ### Security

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed / Breaking
 
+- **BREAKING: `WorksListRequest` and `WorksExportRequest` no longer accept
+  date filter fields** (CUSS-451) — `WorksListRequest` previously exposed
+  `created_date` and `modified_date` fields, and `WorksExportRequest`
+  previously exposed a `created_date` field. These were aspirational: the
+  DevRev PUBLIC API rejects both filters on `/works.list` and
+  `/works.export` with `400 bad-request.bad-request-field`. The fields have
+  been removed from both request models. Existing callers that populate
+  `WorksListRequest(created_date=...)`,
+  `WorksListRequest(modified_date=...)`, or
+  `WorksExportRequest(created_date=...)` will now raise
+  `pydantic.ValidationError` at construction time.
+
+    **Migration**: use the new `WorksService.list_modified_since` /
+    `WorksService.list_created_since` helpers (sync and async), which page
+    server-side sorted `{timestamp_field}:desc` and early-exit on records
+    older than the cutoff. See `docs/api/services/works.md` for examples.
 - **`sort_by` syntax normalization** (CUSS-451) — The DevRev server rejects
   bare `"-field"` entries on `/works.list` and `/conversations.list` and
   requires the canonical `"field:asc"` / `"field:desc"` form. `WorksService`
@@ -61,6 +77,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   filters may not be honored uniformly across older accounts. The new
   helpers apply client-side early-exit on the sorted stream so results are
   bounded by the cutoff even when the server does not filter.
+- **`BaseService._post` serialized non-JSON-native types incorrectly**
+  (CUSS-451) — `BaseService._post` and `AsyncBaseService._post` dumped
+  request models with `model_dump(exclude_none=True, by_alias=True)`, which
+  returns Python-native types (e.g., `datetime` as `datetime` objects
+  rather than ISO 8601 strings). Request bodies containing timestamps — as
+  used by the new `list_modified_since` / `list_created_since` filter
+  payloads — failed to round-trip through the HTTP layer. Both methods now
+  pass `mode="json"` so Pydantic produces JSON-serializable primitives
+  before the request is sent.
 
 ## [2.14.1] - 2026-04-14
 

--- a/docs/mcp/tools-reference.md
+++ b/docs/mcp/tools-reference.md
@@ -10,15 +10,32 @@ Complete reference of all MCP capabilities provided by the DevRev MCP Server.
 
 Tools are the primary way AI assistants interact with DevRev. Each tool maps to one or more DevRev API endpoints.
 
-### Works (Tickets & Issues)
+### Works (Tickets, Issues & Tasks)
+
+In DevRev, **works** is the umbrella type covering tickets (customer support),
+issues (engineering), and tasks.
 
 | Tool | Description |
 |------|-------------|
-| `devrev_works_list` | List work items (tickets, issues) with filters |
+| `devrev_works_list` | List work items with filters and `sort_by` (e.g., `["modified_date:desc"]`) |
 | `devrev_works_get` | Get a specific work item by ID |
-| `devrev_works_create` | Create a new ticket or issue |
+| `devrev_works_create` | Create a new ticket, issue, or task |
 | `devrev_works_update` | Update a work item's fields |
 | `devrev_works_delete` | Delete a work item (requires destructive tools enabled) |
+| `devrev_works_export` | Bulk-export work items (accepts `sort_by`) |
+| `devrev_works_list_modified_since` | List work items with `modified_date >= after` (ISO-8601), paged newest-first |
+| `devrev_works_list_created_since` | List work items with `created_date >= after` (ISO-8601), paged newest-first |
+
+**Key parameters:**
+
+- `sort_by` (on `devrev_works_list` / `devrev_works_export`): List of
+  `"field:asc"` / `"field:desc"` entries. The legacy `"-field"` shortcut is
+  also accepted and normalized by the SDK before the request is sent.
+- `after` (on `*_list_modified_since` / `*_list_created_since`): ISO-8601
+  timestamp (e.g., `"2025-01-15T00:00:00Z"`). Items at or after this
+  timestamp are returned.
+- `limit` (on `*_list_modified_since` / `*_list_created_since`): Hard cap on
+  total items returned across all pages.
 
 ### Accounts
 
@@ -64,10 +81,21 @@ Tools are the primary way AI assistants interact with DevRev. Each tool maps to 
 
 | Tool | Description |
 |------|-------------|
-| `devrev_conversations_list` | List conversations |
+| `devrev_conversations_list` | List conversations; supports `modified_date_after` / `modified_date_before` (ISO-8601) and `sort_by` |
+| `devrev_conversations_list_modified_since` | List conversations with `modified_date >= after` (ISO-8601), paged newest-first |
 | `devrev_conversations_get` | Get conversation details |
 | `devrev_conversations_create` | Create a conversation |
 | `devrev_conversations_update` | Update a conversation |
+
+**Key parameters:**
+
+- `modified_date_after` / `modified_date_before` (on `devrev_conversations_list`):
+  ISO-8601 timestamps bounding the `modified_date` filter.
+- `sort_by` (on `devrev_conversations_list`): Same syntax as on
+  `devrev_works_list` — `"field:asc"` / `"field:desc"` entries, with the
+  legacy `"-field"` shortcut accepted and normalized by the SDK.
+- `after` (on `devrev_conversations_list_modified_since`): ISO-8601
+  timestamp. Items at or after this timestamp are returned.
 
 ### Parts (Products & Features)
 

--- a/openapi-spec-corrections.yaml
+++ b/openapi-spec-corrections.yaml
@@ -220,3 +220,115 @@ components:
           nullable: true
           description: User state
 
+    # ============================================================================
+    # CORRECTION #3: /works.list sort_by syntax (CUSS-451)
+    # ============================================================================
+    #
+    # Issue: OpenAPI spec documents `sort_by` as an array of strings without
+    #   specifying the accepted entry format. The live PUBLIC API rejects
+    #   bare "-field" shortcuts and requires the canonical
+    #   "field:asc" / "field:desc" form.
+    #
+    # Affected Endpoint: POST /works.list (and POST /works.export)
+    # Severity: HIGH - Causes 4xx validation errors for any client that
+    #   relies on the common "-field" descending shortcut.
+    # Ticket: CUSS-451
+    #
+    # Observed server response for `sort_by: ["-modified_date"]`:
+    #   400 Bad Request — "sort_by entries must be of the form
+    #   'field:asc' or 'field:desc'"
+    #
+    # SDK Mitigation: `WorksService.list` / `WorksService.export` normalize
+    #   `sort_by` entries before sending. Callers MAY continue to pass
+    #   "-field" / "field" shortcuts; they are rewritten to
+    #   "field:desc" / "field:asc" on the wire.
+    #
+    # Spec Correction (documentation-only — no schema change needed):
+    WorksListSortByCorrection:
+      type: array
+      description: |
+        Sort order for /works.list results.
+
+        **Required format**: Each entry MUST be `"field:asc"` or
+        `"field:desc"`. The server rejects bare `"-field"` and `"field"`
+        shortcuts.
+
+        **SDK behavior**: The Python SDK normalizes legacy shortcuts to the
+        canonical form before sending, so callers may pass either format to
+        `WorksService.list` / `WorksService.export`.
+      items:
+        type: string
+        pattern: "^[a-zA-Z_][a-zA-Z0-9_.]*:(asc|desc)$"
+        example: "modified_date:desc"
+      example:
+        - "modified_date:desc"
+        - "created_date:asc"
+
+    # ============================================================================
+    # CORRECTION #4: /conversations.list sort_by syntax (CUSS-451)
+    # ============================================================================
+    #
+    # Issue: Same as Correction #3 but on the conversations endpoint. The
+    #   live PUBLIC API rejects bare "-field" entries on
+    #   POST /conversations.list and requires "field:asc" / "field:desc".
+    #
+    # Affected Endpoint: POST /conversations.list
+    # Severity: HIGH - Causes 4xx validation errors.
+    # Ticket: CUSS-451
+    #
+    # SDK Mitigation: `ConversationsService.list` normalizes `sort_by`
+    #   entries before sending.
+    ConversationsListSortByCorrection:
+      type: array
+      description: |
+        Sort order for /conversations.list results.
+
+        **Required format**: Each entry MUST be `"field:asc"` or
+        `"field:desc"`. Matches the corrected syntax documented for
+        /works.list.
+      items:
+        type: string
+        pattern: "^[a-zA-Z_][a-zA-Z0-9_.]*:(asc|desc)$"
+        example: "modified_date:desc"
+      example:
+        - "modified_date:desc"
+
+    # ============================================================================
+    # CORRECTION #5: Time-windowed listing on /works.list and /conversations.list (CUSS-451)
+    # ============================================================================
+    #
+    # Issue: The spec documents `modified_date` / `created_date` filters on
+    #   /works.list and /conversations.list, but server-side filtering is
+    #   not uniformly honored across all accounts. Observed behavior:
+    #     - Some accounts return records older than the declared `after`
+    #       cutoff when paginating results.
+    #     - Sort order is honored reliably when `sort_by` uses the
+    #       `field:direction` form (see Corrections #3 and #4).
+    #
+    # Affected Endpoints: POST /works.list, POST /conversations.list
+    # Severity: MEDIUM - Does not break validation, but causes over-broad
+    #   result sets for clients that rely on the server-side date filter.
+    # Ticket: CUSS-451
+    #
+    # SDK Mitigation: `WorksService.list_modified_since`,
+    #   `WorksService.list_created_since`, and
+    #   `ConversationsService.list_modified_since` page server-side sorted
+    #   `{timestamp_field}:desc` and apply a client-side early-exit as soon
+    #   as a record older than the cutoff is seen. This guarantees the
+    #   returned set is bounded by the cutoff regardless of server-side
+    #   filter behavior.
+    #
+    # Documentation-only correction (no schema change):
+    TimeWindowedListingCorrection:
+      type: object
+      description: |
+        /works.list and /conversations.list support `modified_date` and
+        (for works) `created_date` filters, but server-side honoring of
+        these filters is inconsistent across accounts. Clients that need a
+        strict time-window guarantee should sort by the timestamp field in
+        descending order and early-exit on the first record older than the
+        cutoff.
+      properties:
+        note:
+          type: string
+          example: "See SDK helpers list_modified_since / list_created_since."

--- a/src/devrev/models/conversations.py
+++ b/src/devrev/models/conversations.py
@@ -8,6 +8,7 @@ from typing import Any
 from pydantic import Field
 
 from devrev.models.base import (
+    DateFilter,
     DevRevBaseModel,
     DevRevResponseModel,
     PaginatedResponse,
@@ -63,6 +64,13 @@ class ConversationsListRequest(DevRevBaseModel):
 
     cursor: str | None = Field(default=None, description="Pagination cursor")
     limit: int | None = Field(default=None, ge=1, le=100, description="Max results")
+    modified_date: DateFilter | None = Field(
+        default=None, description="Filter by modification date"
+    )
+    sort_by: list[str] | None = Field(
+        default=None,
+        description='Sort order (e.g., ["modified_date:desc"])',
+    )
 
 
 class ConversationsUpdateRequest(DevRevBaseModel):

--- a/src/devrev/models/works.py
+++ b/src/devrev/models/works.py
@@ -167,15 +167,18 @@ class WorksListRequest(DevRevBaseModel):
     type: list[WorkType] | None = Field(default=None, description="Filter by work types")
     applies_to_part: list[str] | None = Field(default=None, description="Filter by part IDs")
     created_by: list[str] | None = Field(default=None, description="Filter by creator user IDs")
-    created_date: DateFilter | None = Field(default=None, description="Filter by creation date")
     cursor: str | None = Field(default=None, description="Pagination cursor")
     external_ref: list[str] | None = Field(default=None, description="Filter by external refs")
     limit: int | None = Field(default=None, ge=1, le=100, description="Max results to return")
-    modified_date: DateFilter | None = Field(
-        default=None, description="Filter by modification date"
-    )
     owned_by: list[str] | None = Field(default=None, description="Filter by owner user IDs")
-    sort_by: list[str] | None = Field(default=None, description="Sort order")
+    sort_by: list[str] | None = Field(
+        default=None,
+        description=(
+            "Sort order. Each entry uses the server form 'field:asc' or 'field:desc' "
+            "(e.g. 'modified_date:desc'). The legacy '-field' form is accepted by the "
+            "service and normalized before being sent."
+        ),
+    )
     stage_name: list[str] | None = Field(default=None, description="Filter by stage names")
     target_close_date: DateFilter | None = Field(
         default=None, description="Filter by target close date"
@@ -226,8 +229,15 @@ class WorksExportRequest(DevRevBaseModel):
     type: list[WorkType] | None = Field(default=None, description="Filter by work types")
     applies_to_part: list[str] | None = Field(default=None, description="Filter by part IDs")
     created_by: list[str] | None = Field(default=None, description="Filter by creator user IDs")
-    created_date: DateFilter | None = Field(default=None, description="Filter by creation date")
     first: int | None = Field(default=None, ge=1, le=10000, description="Max results")
+    sort_by: list[str] | None = Field(
+        default=None,
+        description=(
+            "Sort order. Each entry uses the server form 'field:asc' or 'field:desc' "
+            "(e.g. 'modified_date:desc'). The legacy '-field' form is accepted by the "
+            "service and normalized before being sent."
+        ),
+    )
 
 
 class WorksCountRequest(DevRevBaseModel):

--- a/src/devrev/services/base.py
+++ b/src/devrev/services/base.py
@@ -72,7 +72,9 @@ class BaseService:
         Returns:
             Parsed response model or raw dict if no response_type
         """
-        data = request.model_dump(exclude_none=True, by_alias=True) if request else None
+        data = (
+            request.model_dump(exclude_none=True, by_alias=True, mode="json") if request else None
+        )
         response = self._http.post(endpoint, data=data)
 
         # Handle empty responses (204 No Content or empty body)
@@ -185,7 +187,9 @@ class AsyncBaseService:
         Returns:
             Parsed response model or raw dict if no response_type
         """
-        data = request.model_dump(exclude_none=True, by_alias=True) if request else None
+        data = (
+            request.model_dump(exclude_none=True, by_alias=True, mode="json") if request else None
+        )
         response = await self._http.post(endpoint, data=data)
 
         # Handle empty responses (204 No Content or empty body)

--- a/src/devrev/services/conversations.py
+++ b/src/devrev/services/conversations.py
@@ -47,18 +47,31 @@ def _normalize_sort_by(sort_by: Sequence[str] | None) -> list[str] | None:
     return normalized
 
 
+# ``ConversationsListRequest.limit`` is pydantic-constrained to ``le=100``;
+# clamp any computed per-page limit so pagination loops do not construct a
+# request body that fails validation before it is ever sent.
+_CONVERSATIONS_MAX_PAGE = 100
+
+
 def _resolve_page_limit(
     overall_limit: int | None,
     collected: int,
     page_size: int | None,
 ) -> int | None:
-    """Compute the ``limit`` to send for the next page request."""
+    """Compute the ``limit`` to send for the next page request.
+
+    The returned value is always clamped to ``_CONVERSATIONS_MAX_PAGE`` so
+    callers using an ``overall_limit`` greater than the server maximum (e.g.
+    ``limit=200, page_size=None``) still paginate correctly.
+    """
     if overall_limit is None:
-        return page_size
+        if page_size is None:
+            return None
+        return min(page_size, _CONVERSATIONS_MAX_PAGE)
     remaining = overall_limit - collected
     if page_size is None:
-        return remaining
-    return min(page_size, remaining)
+        return min(remaining, _CONVERSATIONS_MAX_PAGE)
+    return min(page_size, remaining, _CONVERSATIONS_MAX_PAGE)
 
 
 def _is_before_cutoff(modified_date: datetime | None, cutoff: datetime) -> bool:

--- a/src/devrev/services/conversations.py
+++ b/src/devrev/services/conversations.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import datetime
 from typing import overload
 
+from devrev.models.base import DateFilter
 from devrev.models.conversations import (
     Conversation,
     ConversationExportItem,
@@ -22,6 +24,49 @@ from devrev.models.conversations import (
     ConversationsUpdateResponse,
 )
 from devrev.services.base import AsyncBaseService, BaseService
+
+
+def _normalize_sort_by(sort_by: Sequence[str] | None) -> list[str] | None:
+    """Normalize sort_by entries to the ``field:direction`` format.
+
+    Accepts bare field names (e.g. ``"modified_date"``) or entries already in
+    ``field:direction`` form (e.g. ``"modified_date:desc"``). Bare field names
+    default to ascending order.
+    """
+    if sort_by is None:
+        return None
+    normalized: list[str] = []
+    for entry in sort_by:
+        normalized.append(entry if ":" in entry else f"{entry}:asc")
+    return normalized
+
+
+def _resolve_page_limit(
+    overall_limit: int | None,
+    collected: int,
+    page_size: int | None,
+) -> int | None:
+    """Compute the ``limit`` to send for the next page request."""
+    if overall_limit is None:
+        return page_size
+    remaining = overall_limit - collected
+    if page_size is None:
+        return remaining
+    return min(page_size, remaining)
+
+
+def _is_before_cutoff(modified_date: datetime | None, cutoff: datetime) -> bool:
+    """Return True if ``modified_date`` is strictly older than ``cutoff``.
+
+    Returns False when the timestamp is unknown or when the two datetimes have
+    incompatible tz-awareness; the server-side filter remains authoritative.
+    """
+    if modified_date is None:
+        return False
+    try:
+        return modified_date < cutoff
+    except TypeError:
+        return False
 
 
 class ConversationsService(BaseService):
@@ -43,6 +88,50 @@ class ConversationsService(BaseService):
             request = ConversationsListRequest()
         response = self._post("/conversations.list", request, ConversationsListResponse)
         return response.conversations
+
+    def list_modified_since(
+        self,
+        after: datetime,
+        *,
+        limit: int | None = None,
+        page_size: int | None = None,
+    ) -> Sequence[Conversation]:
+        """List conversations modified after a given datetime, newest first.
+
+        Streams pages via cursor until the server returns no further cursor,
+        ``limit`` is reached, or a conversation older than ``after`` is seen.
+
+        Args:
+            after: Only include conversations modified after this datetime.
+            limit: Maximum number of conversations to return overall.
+            page_size: Number of results per API request; ``None`` defers to server.
+
+        Returns:
+            List of Conversation objects modified after ``after``, newest first.
+        """
+        results: list[Conversation] = []
+        cursor: str | None = None
+        while True:
+            if limit is not None and len(results) >= limit:
+                break
+            request_limit = _resolve_page_limit(limit, len(results), page_size)
+            request = ConversationsListRequest(
+                cursor=cursor,
+                limit=request_limit,
+                modified_date=DateFilter(after=after),
+                sort_by=_normalize_sort_by(["modified_date:desc"]),
+            )
+            response = self._post("/conversations.list", request, ConversationsListResponse)
+            for conversation in response.conversations:
+                if _is_before_cutoff(conversation.modified_date, after):
+                    return results
+                results.append(conversation)
+                if limit is not None and len(results) >= limit:
+                    return results
+            if not response.next_cursor:
+                break
+            cursor = response.next_cursor
+        return results
 
     def update(self, request: ConversationsUpdateRequest) -> Conversation:
         """Update a conversation."""
@@ -129,6 +218,50 @@ class AsyncConversationsService(AsyncBaseService):
             request = ConversationsListRequest()
         response = await self._post("/conversations.list", request, ConversationsListResponse)
         return response.conversations
+
+    async def list_modified_since(
+        self,
+        after: datetime,
+        *,
+        limit: int | None = None,
+        page_size: int | None = None,
+    ) -> Sequence[Conversation]:
+        """List conversations modified after a given datetime, newest first.
+
+        Streams pages via cursor until the server returns no further cursor,
+        ``limit`` is reached, or a conversation older than ``after`` is seen.
+
+        Args:
+            after: Only include conversations modified after this datetime.
+            limit: Maximum number of conversations to return overall.
+            page_size: Number of results per API request; ``None`` defers to server.
+
+        Returns:
+            List of Conversation objects modified after ``after``, newest first.
+        """
+        results: list[Conversation] = []
+        cursor: str | None = None
+        while True:
+            if limit is not None and len(results) >= limit:
+                break
+            request_limit = _resolve_page_limit(limit, len(results), page_size)
+            request = ConversationsListRequest(
+                cursor=cursor,
+                limit=request_limit,
+                modified_date=DateFilter(after=after),
+                sort_by=_normalize_sort_by(["modified_date:desc"]),
+            )
+            response = await self._post("/conversations.list", request, ConversationsListResponse)
+            for conversation in response.conversations:
+                if _is_before_cutoff(conversation.modified_date, after):
+                    return results
+                results.append(conversation)
+                if limit is not None and len(results) >= limit:
+                    return results
+            if not response.next_cursor:
+                break
+            cursor = response.next_cursor
+        return results
 
     async def update(self, request: ConversationsUpdateRequest) -> Conversation:
         """Update a conversation."""

--- a/src/devrev/services/conversations.py
+++ b/src/devrev/services/conversations.py
@@ -29,15 +29,21 @@ from devrev.services.base import AsyncBaseService, BaseService
 def _normalize_sort_by(sort_by: Sequence[str] | None) -> list[str] | None:
     """Normalize sort_by entries to the ``field:direction`` format.
 
-    Accepts bare field names (e.g. ``"modified_date"``) or entries already in
-    ``field:direction`` form (e.g. ``"modified_date:desc"``). Bare field names
+    Accepts entries already in ``field:direction`` form (e.g.
+    ``"modified_date:desc"``), the legacy ``"-field"`` shorthand for
+    descending order, and bare field names (e.g. ``"modified_date"``) which
     default to ascending order.
     """
     if sort_by is None:
         return None
     normalized: list[str] = []
     for entry in sort_by:
-        normalized.append(entry if ":" in entry else f"{entry}:asc")
+        if ":" in entry:
+            normalized.append(entry)
+        elif entry.startswith("-"):
+            normalized.append(f"{entry[1:]}:desc")
+        else:
+            normalized.append(f"{entry}:asc")
     return normalized
 
 
@@ -86,6 +92,8 @@ class ConversationsService(BaseService):
         """List conversations."""
         if request is None:
             request = ConversationsListRequest()
+        if request.sort_by is not None:
+            request.sort_by = _normalize_sort_by(request.sort_by)
         response = self._post("/conversations.list", request, ConversationsListResponse)
         return response.conversations
 
@@ -216,6 +224,8 @@ class AsyncConversationsService(AsyncBaseService):
         """List conversations."""
         if request is None:
             request = ConversationsListRequest()
+        if request.sort_by is not None:
+            request.sort_by = _normalize_sort_by(request.sort_by)
         response = await self._post("/conversations.list", request, ConversationsListResponse)
         return response.conversations
 

--- a/src/devrev/services/works.py
+++ b/src/devrev/services/works.py
@@ -58,6 +58,31 @@ def _is_before_cutoff(timestamp: datetime | None, cutoff: datetime) -> bool:
         return False
 
 
+# ``WorksListRequest.limit`` is pydantic-constrained to ``le=100``; clamp any
+# computed per-page limit so pagination loops do not construct a request body
+# that fails validation before it is ever sent.
+_WORKS_MAX_PAGE = 100
+
+
+def _resolve_page_limit(
+    overall_limit: int | None,
+    collected: int,
+    page_size: int | None,
+) -> int | None:
+    """Compute the ``limit`` to send for the next page request.
+
+    The returned value is always clamped to ``_WORKS_MAX_PAGE`` so callers using
+    an ``overall_limit`` greater than the server maximum (e.g. ``limit=200,
+    page_size=None``) still paginate correctly.
+    """
+    if page_size is not None:
+        return min(page_size, _WORKS_MAX_PAGE)
+    if overall_limit is None:
+        return None
+    remaining = overall_limit - collected
+    return min(remaining, _WORKS_MAX_PAGE)
+
+
 def _normalize_sort_by(sort_by: Sequence[str] | None) -> _StrList | None:
     """Normalize sort_by entries to the server-expected ``field:direction`` form.
 
@@ -326,7 +351,7 @@ class WorksService(BaseService):
                 owned_by=owned_by,
                 applies_to_part=applies_to_part,
                 cursor=cursor,
-                limit=page_size,
+                limit=_resolve_page_limit(limit, len(collected), page_size),
                 sort_by=sort_by,
             )
             stop = False
@@ -552,7 +577,7 @@ class AsyncWorksService(AsyncBaseService):
                 owned_by=owned_by,
                 applies_to_part=applies_to_part,
                 cursor=cursor,
-                limit=page_size,
+                limit=_resolve_page_limit(limit, len(collected), page_size),
                 sort_by=sort_by,
             )
             stop = False

--- a/src/devrev/services/works.py
+++ b/src/devrev/services/works.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from devrev.models.base import DateFilter, StageUpdate
+from devrev.models.base import StageUpdate
 from devrev.models.works import (
     IssuePriority,
     TicketSeverity,
@@ -35,6 +35,35 @@ from devrev.services.base import AsyncBaseService, BaseService
 
 if TYPE_CHECKING:
     from devrev.utils.http import AsyncHTTPClient, HTTPClient
+
+
+# Module-level type aliases. Declared here so class-scoped annotations can
+# refer to ``list[...]`` without colliding with the ``list`` method defined on
+# :class:`WorksService` / :class:`AsyncWorksService`.
+_WorkList = list[Work]
+_StrList = list[str]
+
+
+def _normalize_sort_by(sort_by: Sequence[str] | None) -> _StrList | None:
+    """Normalize sort_by entries to the server-expected ``field:direction`` form.
+
+    Accepts both the legacy ``"-field"`` (descending) / ``"field"`` (ascending)
+    shorthand and the explicit ``"field:asc"`` / ``"field:desc"`` form. Returns
+    a new list with every entry in the ``"field:direction"`` form. Returns
+    ``None`` when the input is ``None`` so callers can pass the result straight
+    through to request models with no-op semantics.
+    """
+    if sort_by is None:
+        return None
+    normalized: list[str] = []
+    for entry in sort_by:
+        if ":" in entry:
+            normalized.append(entry)
+        elif entry.startswith("-"):
+            normalized.append(f"{entry[1:]}:desc")
+        else:
+            normalized.append(f"{entry}:asc")
+    return normalized
 
 
 class WorksService(BaseService):
@@ -109,10 +138,10 @@ class WorksService(BaseService):
         type: Sequence[WorkType] | None = None,
         applies_to_part: Sequence[str] | None = None,
         created_by: Sequence[str] | None = None,
-        created_date: DateFilter | None = None,
         cursor: str | None = None,
         limit: int | None = None,
         owned_by: Sequence[str] | None = None,
+        sort_by: Sequence[str] | None = None,
         stage_name: Sequence[str] | None = None,
     ) -> WorksListResponse:
         """List work items.
@@ -121,10 +150,12 @@ class WorksService(BaseService):
             type: Filter by work types
             applies_to_part: Filter by part IDs
             created_by: Filter by creator user IDs
-            created_date: Filter by creation date
             cursor: Pagination cursor
             limit: Maximum number of results
             owned_by: Filter by owner user IDs
+            sort_by: Sort order. Accepts either the server form
+                ``"field:asc"`` / ``"field:desc"`` or the legacy
+                ``"-field"`` shorthand; the client normalizes before sending.
             stage_name: Filter by stage names
 
         Returns:
@@ -134,10 +165,10 @@ class WorksService(BaseService):
             type=type,
             applies_to_part=applies_to_part,
             created_by=created_by,
-            created_date=created_date,
             cursor=cursor,
             limit=limit,
             owned_by=owned_by,
+            sort_by=_normalize_sort_by(sort_by),
             stage_name=stage_name,
         )
         return self._post("/works.list", request, WorksListResponse)
@@ -198,8 +229,8 @@ class WorksService(BaseService):
         type: Sequence[WorkType] | None = None,
         applies_to_part: Sequence[str] | None = None,
         created_by: Sequence[str] | None = None,
-        created_date: DateFilter | None = None,
         first: int | None = None,
+        sort_by: Sequence[str] | None = None,
     ) -> Sequence[Work]:
         """Export work items.
 
@@ -207,8 +238,10 @@ class WorksService(BaseService):
             type: Filter by work types
             applies_to_part: Filter by part IDs
             created_by: Filter by creator user IDs
-            created_date: Filter by creation date
             first: Maximum number of results
+            sort_by: Sort order. Accepts either the server form
+                ``"field:asc"`` / ``"field:desc"`` or the legacy
+                ``"-field"`` shorthand; the client normalizes before sending.
 
         Returns:
             List of exported work items
@@ -217,8 +250,8 @@ class WorksService(BaseService):
             type=type,
             applies_to_part=applies_to_part,
             created_by=created_by,
-            created_date=created_date,
             first=first,
+            sort_by=_normalize_sort_by(sort_by),
         )
         response = self._post("/works.export", request, WorksExportResponse)
         return response.works
@@ -250,6 +283,104 @@ class WorksService(BaseService):
         )
         response = self._post("/works.count", request, WorksCountResponse)
         return response.count
+
+    def _list_since(
+        self,
+        after: datetime,
+        timestamp_field: str,
+        *,
+        type: Sequence[WorkType] | None,
+        owned_by: Sequence[str] | None,
+        applies_to_part: Sequence[str] | None,
+        limit: int | None,
+        page_size: int | None,
+    ) -> _WorkList:
+        """Shared cursor-paginated fetcher for ``list_*_since`` helpers.
+
+        Streams pages sorted ``{timestamp_field}:desc`` and early-exits as soon
+        as a record's timestamp is strictly older than ``after``. Respects
+        ``limit`` as a hard cap on returned items.
+        """
+        sort_by = [f"{timestamp_field}:desc"]
+        collected: _WorkList = []
+        cursor: str | None = None
+        while True:
+            if limit is not None and len(collected) >= limit:
+                break
+            page = self.list(
+                type=type,
+                owned_by=owned_by,
+                applies_to_part=applies_to_part,
+                cursor=cursor,
+                limit=page_size,
+                sort_by=sort_by,
+            )
+            stop = False
+            for work in page.works:
+                timestamp = getattr(work, timestamp_field, None)
+                if timestamp is not None and timestamp < after:
+                    stop = True
+                    break
+                collected.append(work)
+                if limit is not None and len(collected) >= limit:
+                    stop = True
+                    break
+            if stop or not page.next_cursor:
+                break
+            cursor = page.next_cursor
+        return collected
+
+    def list_modified_since(
+        self,
+        after: datetime,
+        *,
+        type: Sequence[WorkType] | None = None,
+        owned_by: Sequence[str] | None = None,
+        applies_to_part: Sequence[str] | None = None,
+        limit: int | None = None,
+        page_size: int | None = None,
+    ) -> _WorkList:
+        """Return work items modified at or after ``after``.
+
+        Pages through ``works.list`` sorted by ``modified_date:desc`` and stops
+        as soon as it sees a record older than ``after``. Uses ``limit`` as a
+        hard cap when provided.
+        """
+        return self._list_since(
+            after,
+            "modified_date",
+            type=type,
+            owned_by=owned_by,
+            applies_to_part=applies_to_part,
+            limit=limit,
+            page_size=page_size,
+        )
+
+    def list_created_since(
+        self,
+        after: datetime,
+        *,
+        type: Sequence[WorkType] | None = None,
+        owned_by: Sequence[str] | None = None,
+        applies_to_part: Sequence[str] | None = None,
+        limit: int | None = None,
+        page_size: int | None = None,
+    ) -> _WorkList:
+        """Return work items created at or after ``after``.
+
+        Pages through ``works.list`` sorted by ``created_date:desc`` and stops
+        as soon as it sees a record older than ``after``. Uses ``limit`` as a
+        hard cap when provided.
+        """
+        return self._list_since(
+            after,
+            "created_date",
+            type=type,
+            owned_by=owned_by,
+            applies_to_part=applies_to_part,
+            limit=limit,
+            page_size=page_size,
+        )
 
 
 class AsyncWorksService(AsyncBaseService):
@@ -301,14 +432,21 @@ class AsyncWorksService(AsyncBaseService):
         cursor: str | None = None,
         limit: int | None = None,
         owned_by: Sequence[str] | None = None,
+        sort_by: Sequence[str] | None = None,
     ) -> WorksListResponse:
-        """List work items."""
+        """List work items.
+
+        ``sort_by`` accepts either the server form ``"field:asc"`` /
+        ``"field:desc"`` or the legacy ``"-field"`` shorthand; the client
+        normalizes before sending.
+        """
         request = WorksListRequest(
             type=type,
             applies_to_part=applies_to_part,
             cursor=cursor,
             limit=limit,
             owned_by=owned_by,
+            sort_by=_normalize_sort_by(sort_by),
         )
         return await self._post("/works.list", request, WorksListResponse)
 
@@ -345,9 +483,19 @@ class AsyncWorksService(AsyncBaseService):
         *,
         type: Sequence[WorkType] | None = None,
         first: int | None = None,
+        sort_by: Sequence[str] | None = None,
     ) -> Sequence[Work]:
-        """Export work items."""
-        request = WorksExportRequest(type=type, first=first)
+        """Export work items.
+
+        ``sort_by`` accepts either the server form ``"field:asc"`` /
+        ``"field:desc"`` or the legacy ``"-field"`` shorthand; the client
+        normalizes before sending.
+        """
+        request = WorksExportRequest(
+            type=type,
+            first=first,
+            sort_by=_normalize_sort_by(sort_by),
+        )
         response = await self._post("/works.export", request, WorksExportResponse)
         return response.works
 
@@ -361,3 +509,101 @@ class AsyncWorksService(AsyncBaseService):
         request = WorksCountRequest(type=type, owned_by=owned_by)
         response = await self._post("/works.count", request, WorksCountResponse)
         return response.count
+
+    async def _list_since(
+        self,
+        after: datetime,
+        timestamp_field: str,
+        *,
+        type: Sequence[WorkType] | None,
+        owned_by: Sequence[str] | None,
+        applies_to_part: Sequence[str] | None,
+        limit: int | None,
+        page_size: int | None,
+    ) -> _WorkList:
+        """Shared cursor-paginated fetcher for async ``list_*_since`` helpers.
+
+        Streams pages sorted ``{timestamp_field}:desc`` and early-exits as soon
+        as a record's timestamp is strictly older than ``after``. Respects
+        ``limit`` as a hard cap on returned items.
+        """
+        sort_by = [f"{timestamp_field}:desc"]
+        collected: _WorkList = []
+        cursor: str | None = None
+        while True:
+            if limit is not None and len(collected) >= limit:
+                break
+            page = await self.list(
+                type=type,
+                owned_by=owned_by,
+                applies_to_part=applies_to_part,
+                cursor=cursor,
+                limit=page_size,
+                sort_by=sort_by,
+            )
+            stop = False
+            for work in page.works:
+                timestamp = getattr(work, timestamp_field, None)
+                if timestamp is not None and timestamp < after:
+                    stop = True
+                    break
+                collected.append(work)
+                if limit is not None and len(collected) >= limit:
+                    stop = True
+                    break
+            if stop or not page.next_cursor:
+                break
+            cursor = page.next_cursor
+        return collected
+
+    async def list_modified_since(
+        self,
+        after: datetime,
+        *,
+        type: Sequence[WorkType] | None = None,
+        owned_by: Sequence[str] | None = None,
+        applies_to_part: Sequence[str] | None = None,
+        limit: int | None = None,
+        page_size: int | None = None,
+    ) -> _WorkList:
+        """Return work items modified at or after ``after``.
+
+        Pages through ``works.list`` sorted by ``modified_date:desc`` and stops
+        as soon as it sees a record older than ``after``. Uses ``limit`` as a
+        hard cap when provided.
+        """
+        return await self._list_since(
+            after,
+            "modified_date",
+            type=type,
+            owned_by=owned_by,
+            applies_to_part=applies_to_part,
+            limit=limit,
+            page_size=page_size,
+        )
+
+    async def list_created_since(
+        self,
+        after: datetime,
+        *,
+        type: Sequence[WorkType] | None = None,
+        owned_by: Sequence[str] | None = None,
+        applies_to_part: Sequence[str] | None = None,
+        limit: int | None = None,
+        page_size: int | None = None,
+    ) -> _WorkList:
+        """Return work items created at or after ``after``.
+
+        Pages through ``works.list`` sorted by ``created_date:desc`` and stops
+        as soon as it sees a record older than ``after``. Uses ``limit`` as a
+        hard cap when provided.
+        """
+        return await self._list_since(
+            after,
+            "created_date",
+            type=type,
+            owned_by=owned_by,
+            applies_to_part=applies_to_part,
+            limit=limit,
+            page_size=page_size,
+        )

--- a/src/devrev/services/works.py
+++ b/src/devrev/services/works.py
@@ -44,6 +44,20 @@ _WorkList = list[Work]
 _StrList = list[str]
 
 
+def _is_before_cutoff(timestamp: datetime | None, cutoff: datetime) -> bool:
+    """Return True if ``timestamp`` is strictly older than ``cutoff``.
+
+    Returns False when the timestamp is unknown or when the two datetimes have
+    incompatible tz-awareness; the server-side filter remains authoritative.
+    """
+    if timestamp is None:
+        return False
+    try:
+        return timestamp < cutoff
+    except TypeError:
+        return False
+
+
 def _normalize_sort_by(sort_by: Sequence[str] | None) -> _StrList | None:
     """Normalize sort_by entries to the server-expected ``field:direction`` form.
 
@@ -318,7 +332,7 @@ class WorksService(BaseService):
             stop = False
             for work in page.works:
                 timestamp = getattr(work, timestamp_field, None)
-                if timestamp is not None and timestamp < after:
+                if _is_before_cutoff(timestamp, after):
                     stop = True
                     break
                 collected.append(work)
@@ -544,7 +558,7 @@ class AsyncWorksService(AsyncBaseService):
             stop = False
             for work in page.works:
                 timestamp = getattr(work, timestamp_field, None)
-                if timestamp is not None and timestamp < after:
+                if _is_before_cutoff(timestamp, after):
                     stop = True
                     break
                 collected.append(work)

--- a/src/devrev_mcp/tools/conversations.py
+++ b/src/devrev_mcp/tools/conversations.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any
 
 from mcp.server.fastmcp import Context
 
 from devrev.exceptions import DevRevError
+from devrev.models.base import DateFilter
 from devrev.models.conversations import (
     ConversationsCreateRequest,
     ConversationsDeleteRequest,
@@ -24,27 +26,102 @@ from devrev_mcp.utils.pagination import clamp_page_size, paginated_response
 logger = logging.getLogger(__name__)
 
 
+def _parse_iso_datetime(value: str, field_name: str) -> datetime:
+    """Parse an ISO-8601 datetime string, accepting a trailing ``Z`` for UTC.
+
+    Args:
+        value: The ISO-8601 datetime string.
+        field_name: Name of the parameter being parsed (for error messages).
+
+    Returns:
+        A parsed ``datetime`` instance.
+
+    Raises:
+        RuntimeError: If the string cannot be parsed.
+    """
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as e:
+        raise RuntimeError(
+            f"Invalid {field_name} format: {value}. "
+            "Use ISO-8601 format (e.g., 2025-01-01T00:00:00Z)."
+        ) from e
+
+
 @mcp.tool()
 async def devrev_conversations_list(
     ctx: Context[Any, Any, Any],
     cursor: str | None = None,
     limit: int | None = None,
+    modified_date_after: str | None = None,
+    modified_date_before: str | None = None,
+    sort_by: list[str] | None = None,
 ) -> dict[str, Any]:
     """List DevRev conversations.
 
     Args:
         cursor: Pagination cursor from a previous response.
         limit: Maximum number of items to return (default: 25, max: 100).
+        modified_date_after: Only include conversations modified after this
+            ISO-8601 timestamp (e.g., "2025-01-01T00:00:00Z").
+        modified_date_before: Only include conversations modified before this
+            ISO-8601 timestamp.
+        sort_by: Sort order entries (e.g., ["modified_date:desc"] or
+            ["-modified_date"]).
     """
     app = ctx.request_context.lifespan_context
     try:
+        modified_date: DateFilter | None = None
+        if modified_date_after is not None or modified_date_before is not None:
+            after_dt = (
+                _parse_iso_datetime(modified_date_after, "modified_date_after")
+                if modified_date_after is not None
+                else None
+            )
+            before_dt = (
+                _parse_iso_datetime(modified_date_before, "modified_date_before")
+                if modified_date_before is not None
+                else None
+            )
+            modified_date = DateFilter(after=after_dt, before=before_dt)
         request = ConversationsListRequest(
             cursor=cursor,
             limit=clamp_page_size(
                 limit, default=app.config.default_page_size, maximum=app.config.max_page_size
             ),
+            modified_date=modified_date,
+            sort_by=sort_by,
         )
         conversations = await app.get_client().conversations.list(request)
+        items = serialize_models(list(conversations))
+        return {"count": len(items), "conversations": items}
+    except DevRevError as e:
+        raise RuntimeError(format_devrev_error(e)) from e
+
+
+@mcp.tool()
+async def devrev_conversations_list_modified_since(
+    ctx: Context[Any, Any, Any],
+    after: str,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """List DevRev conversations modified after a given ISO-8601 datetime.
+
+    Streams pages newest-first, stopping when the cutoff is crossed or the
+    ``limit`` is reached. The cutoff is supplied as an ISO-8601 string.
+
+    Args:
+        after: ISO-8601 datetime; only conversations modified after this are
+            returned (e.g., "2025-01-01T00:00:00Z").
+        limit: Maximum number of conversations to return overall.
+    """
+    app = ctx.request_context.lifespan_context
+    after_dt = _parse_iso_datetime(after, "after")
+    try:
+        conversations = await app.get_client().conversations.list_modified_since(
+            after=after_dt,
+            limit=limit,
+        )
         items = serialize_models(list(conversations))
         return {"count": len(items), "conversations": items}
     except DevRevError as e:

--- a/src/devrev_mcp/tools/works.py
+++ b/src/devrev_mcp/tools/works.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any
 
 from mcp.server.fastmcp import Context
@@ -18,6 +19,17 @@ from devrev_mcp.utils.pagination import clamp_page_size, paginated_response
 logger = logging.getLogger(__name__)
 
 
+def _parse_iso_after(value: str, param_name: str) -> datetime:
+    """Parse an ISO-8601 timestamp, accepting a trailing ``Z`` for UTC."""
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as e:
+        raise RuntimeError(
+            f"Invalid {param_name} format: {value}. "
+            "Use ISO-8601 (e.g., 2024-01-15T00:00:00Z or 2024-01-15T00:00:00+00:00)."
+        ) from e
+
+
 @mcp.tool()
 async def devrev_works_list(
     ctx: Context[Any, Any, Any],
@@ -26,8 +38,12 @@ async def devrev_works_list(
     owned_by: list[str] | None = None,
     cursor: str | None = None,
     limit: int | None = None,
+    sort_by: list[str] | None = None,
 ) -> dict[str, Any]:
-    """List DevRev work items (tickets, issues, tasks).
+    """List DevRev work items (tickets, issues, and tasks).
+
+    Work items in DevRev include tickets (customer-facing), issues (internal
+    engineering), and tasks. Use the ``type`` filter to scope results.
 
     Args:
         type: Filter by work type(s): TICKET, ISSUE, TASK, OPPORTUNITY.
@@ -35,6 +51,8 @@ async def devrev_works_list(
         owned_by: Filter by owner user ID(s).
         cursor: Pagination cursor from a previous response.
         limit: Maximum number of items to return (default: 25, max: 100).
+        sort_by: Sort order as a list of ``"field:asc"`` / ``"field:desc"``
+            entries (or legacy ``"-field"`` shorthand), forwarded to the SDK.
     """
     app = ctx.request_context.lifespan_context
     try:
@@ -56,6 +74,7 @@ async def devrev_works_list(
             limit=clamp_page_size(
                 limit, default=app.config.default_page_size, maximum=app.config.max_page_size
             ),
+            sort_by=sort_by,
         )
         items = serialize_models(response.works)
         return paginated_response(items, next_cursor=response.next_cursor, total_label="works")
@@ -68,7 +87,7 @@ async def devrev_works_get(
     ctx: Context[Any, Any, Any],
     id: str,
 ) -> dict[str, Any]:
-    """Get a DevRev work item by ID.
+    """Get a DevRev work item (ticket, issue, or task) by ID.
 
     Args:
         id: The work item ID (e.g., don:core:dvrv-us-1:devo/1:issue/123).
@@ -161,7 +180,7 @@ if _config.enable_destructive_tools:
         priority: str | None = None,
         severity: str | None = None,
     ) -> dict[str, Any]:
-        """Update an existing DevRev work item.
+        """Update an existing DevRev work item (ticket, issue, or task).
 
         Only provided fields will be updated; others remain unchanged.
 
@@ -214,7 +233,7 @@ if _config.enable_destructive_tools:
         ctx: Context[Any, Any, Any],
         id: str,
     ) -> dict[str, Any]:
-        """Delete a DevRev work item.
+        """Delete a DevRev work item (ticket, issue, or task).
 
         Args:
             id: The work item ID to delete.
@@ -234,7 +253,7 @@ async def devrev_works_count(
     type: list[str] | None = None,
     owned_by: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Count DevRev work items matching filters.
+    """Count DevRev work items (tickets, issues, and tasks) matching filters.
 
     Args:
         type: Filter by work type(s): TICKET, ISSUE, TASK, OPPORTUNITY.
@@ -263,14 +282,17 @@ async def devrev_works_export(
     ctx: Context[Any, Any, Any],
     type: list[str] | None = None,
     first: int | None = None,
+    sort_by: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Export DevRev work items.
+    """Export DevRev work items (tickets, issues, and tasks).
 
     Returns a bulk export of work items. Use for large data retrieval.
 
     Args:
         type: Filter by work type(s): TICKET, ISSUE, TASK, OPPORTUNITY.
         first: Maximum number of items to export.
+        sort_by: Sort order as a list of ``"field:asc"`` / ``"field:desc"``
+            entries (or legacy ``"-field"`` shorthand), forwarded to the SDK.
     """
     app = ctx.request_context.lifespan_context
     try:
@@ -284,8 +306,102 @@ async def devrev_works_export(
                     f"Invalid work type: {e.args[0]}. "
                     f"Valid types: {', '.join(wt.name for wt in WorkType)}"
                 ) from e
-        works = await app.get_client().works.export(type=work_types, first=first)
+        works = await app.get_client().works.export(type=work_types, first=first, sort_by=sort_by)
         items = serialize_models(list(works))
         return {"count": len(items), "works": items}
+    except DevRevError as e:
+        raise RuntimeError(format_devrev_error(e)) from e
+
+
+@mcp.tool()
+async def devrev_works_list_modified_since(
+    ctx: Context[Any, Any, Any],
+    after: str,
+    type: list[str] | None = None,
+    owned_by: list[str] | None = None,
+    applies_to_part: list[str] | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """List DevRev work items (tickets, issues, and tasks) modified at or after a timestamp.
+
+    Pages through results server-side sorted by ``modified_date:desc`` and
+    returns all matches. Use ``limit`` as a hard cap on total items.
+
+    Args:
+        after: ISO-8601 timestamp (e.g., ``2024-01-15T00:00:00Z``). Items with
+            ``modified_date >= after`` are returned.
+        type: Filter by work type(s): TICKET, ISSUE, TASK, OPPORTUNITY.
+        owned_by: Filter by owner user ID(s).
+        applies_to_part: Filter by part ID(s) the work applies to.
+        limit: Maximum total items to return across all pages.
+    """
+    after_dt = _parse_iso_after(after, "after")
+    app = ctx.request_context.lifespan_context
+    try:
+        work_types = None
+        if type:
+            try:
+                work_types = [WorkType[t.upper()] for t in type]
+            except KeyError as e:
+                raise RuntimeError(
+                    f"Invalid work type: {e.args[0]}. "
+                    f"Valid types: {', '.join(wt.name for wt in WorkType)}"
+                ) from e
+        works = await app.get_client().works.list_modified_since(
+            after_dt,
+            type=work_types,
+            owned_by=owned_by,
+            applies_to_part=applies_to_part,
+            limit=limit,
+        )
+        items = serialize_models(list(works))
+        return paginated_response(items, next_cursor=None, total_label="works")
+    except DevRevError as e:
+        raise RuntimeError(format_devrev_error(e)) from e
+
+
+@mcp.tool()
+async def devrev_works_list_created_since(
+    ctx: Context[Any, Any, Any],
+    after: str,
+    type: list[str] | None = None,
+    owned_by: list[str] | None = None,
+    applies_to_part: list[str] | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """List DevRev work items (tickets, issues, and tasks) created at or after a timestamp.
+
+    Pages through results server-side sorted by ``created_date:desc`` and
+    returns all matches. Use ``limit`` as a hard cap on total items.
+
+    Args:
+        after: ISO-8601 timestamp (e.g., ``2024-01-15T00:00:00Z``). Items with
+            ``created_date >= after`` are returned.
+        type: Filter by work type(s): TICKET, ISSUE, TASK, OPPORTUNITY.
+        owned_by: Filter by owner user ID(s).
+        applies_to_part: Filter by part ID(s) the work applies to.
+        limit: Maximum total items to return across all pages.
+    """
+    after_dt = _parse_iso_after(after, "after")
+    app = ctx.request_context.lifespan_context
+    try:
+        work_types = None
+        if type:
+            try:
+                work_types = [WorkType[t.upper()] for t in type]
+            except KeyError as e:
+                raise RuntimeError(
+                    f"Invalid work type: {e.args[0]}. "
+                    f"Valid types: {', '.join(wt.name for wt in WorkType)}"
+                ) from e
+        works = await app.get_client().works.list_created_since(
+            after_dt,
+            type=work_types,
+            owned_by=owned_by,
+            applies_to_part=applies_to_part,
+            limit=limit,
+        )
+        items = serialize_models(list(works))
+        return paginated_response(items, next_cursor=None, total_label="works")
     except DevRevError as e:
         raise RuntimeError(format_devrev_error(e)) from e

--- a/tests/integration/test_date_filtering.py
+++ b/tests/integration/test_date_filtering.py
@@ -1,0 +1,76 @@
+"""Integration smoke tests for date-based listing helpers.
+
+Verifies that ``list_modified_since`` on works and conversations returns
+records whose ``modified_date`` is at or after the requested cutoff, and
+respects the ``limit`` cap. Tests are read-only and gated on
+``DEVREV_API_TOKEN`` being set.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from devrev import DevRevClient
+from devrev.models.works import WorkType
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("DEVREV_API_TOKEN"),
+        reason="DEVREV_API_TOKEN environment variable not set",
+    ),
+]
+
+
+@pytest.fixture
+def client() -> DevRevClient:
+    """Create a DevRev client using the ambient DEVREV_API_TOKEN."""
+    return DevRevClient()
+
+
+def test_works_list_modified_since_returns_recent_tickets(client: DevRevClient) -> None:
+    """Tickets modified in the last 24h are returned with modified_date >= cutoff."""
+    after = datetime.now(tz=UTC) - timedelta(hours=24)
+
+    result = client.works.list_modified_since(
+        after=after,
+        type=[WorkType.TICKET],
+        limit=5,
+    )
+
+    assert len(result) <= 5
+
+    for work in result:
+        if work.modified_date is not None:
+            assert work.modified_date >= after, (
+                f"Work {work.id} modified_date {work.modified_date} is older than cutoff {after}"
+            )
+        else:
+            logger.info("Work %s has no modified_date; skipping cutoff assertion", work.id)
+
+
+def test_conversations_list_modified_since_returns_recent(client: DevRevClient) -> None:
+    """Conversations modified in the last 24h are returned with modified_date >= cutoff."""
+    after = datetime.now(tz=UTC) - timedelta(hours=24)
+
+    result = client.conversations.list_modified_since(after=after, limit=5)
+
+    assert len(result) <= 5
+
+    for conversation in result:
+        if conversation.modified_date is not None:
+            assert conversation.modified_date >= after, (
+                f"Conversation {conversation.id} modified_date "
+                f"{conversation.modified_date} is older than cutoff {after}"
+            )
+        else:
+            logger.info(
+                "Conversation %s has no modified_date; skipping cutoff assertion",
+                conversation.id,
+            )

--- a/tests/integration/test_date_filtering.py
+++ b/tests/integration/test_date_filtering.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -29,9 +30,10 @@ pytestmark = [
 
 
 @pytest.fixture
-def client() -> DevRevClient:
+def client() -> Iterator[DevRevClient]:
     """Create a DevRev client using the ambient DEVREV_API_TOKEN."""
-    return DevRevClient()
+    with DevRevClient() as c:
+        yield c
 
 
 def test_works_list_modified_since_returns_recent_tickets(client: DevRevClient) -> None:

--- a/tests/unit/mcp/conftest.py
+++ b/tests/unit/mcp/conftest.py
@@ -99,6 +99,7 @@ def mock_client():
     # Conversations service
     client.conversations = AsyncMock()
     client.conversations.list = AsyncMock()
+    client.conversations.list_modified_since = AsyncMock()
     client.conversations.get = AsyncMock()
     client.conversations.create = AsyncMock()
     client.conversations.update = AsyncMock()

--- a/tests/unit/mcp/test_tools_conversations.py
+++ b/tests/unit/mcp/test_tools_conversations.py
@@ -2,17 +2,21 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
 
 from devrev.exceptions import NotFoundError, ValidationError
+from devrev.models.base import DateFilter
+from devrev.models.conversations import ConversationsListRequest
 from devrev_mcp.tools.conversations import (
     devrev_conversations_create,
     devrev_conversations_delete,
     devrev_conversations_export,
     devrev_conversations_get,
     devrev_conversations_list,
+    devrev_conversations_list_modified_since,
     devrev_conversations_update,
 )
 
@@ -280,3 +284,138 @@ class TestConversationsExportTool:
         # Act & Assert
         with pytest.raises(RuntimeError, match="Export endpoint not available"):
             await devrev_conversations_export(mock_ctx)
+
+
+class TestConversationsListDateFilterAndSort:
+    """Tests for modified_date_*/sort_by handling on devrev_conversations_list."""
+
+    @staticmethod
+    def _call_request(mock_client) -> ConversationsListRequest:
+        """Return the ConversationsListRequest passed to the SDK list mock."""
+        args, kwargs = mock_client.conversations.list.call_args
+        if args:
+            return args[0]
+        return kwargs["request"]
+
+    async def test_list_forwards_modified_date_after(self, mock_ctx, mock_client):
+        """modified_date_after (with trailing Z) builds a DateFilter.after."""
+        mock_client.conversations.list.return_value = []
+
+        await devrev_conversations_list(mock_ctx, modified_date_after="2025-01-01T00:00:00Z")
+
+        request = self._call_request(mock_client)
+        assert isinstance(request.modified_date, DateFilter)
+        assert request.modified_date.after == datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+        assert request.modified_date.before is None
+
+    async def test_list_forwards_modified_date_before(self, mock_ctx, mock_client):
+        """modified_date_before (no trailing Z) builds a DateFilter.before."""
+        mock_client.conversations.list.return_value = []
+
+        await devrev_conversations_list(mock_ctx, modified_date_before="2025-02-01T12:30:00+00:00")
+
+        request = self._call_request(mock_client)
+        assert isinstance(request.modified_date, DateFilter)
+        assert request.modified_date.after is None
+        assert request.modified_date.before == datetime(2025, 2, 1, 12, 30, 0, tzinfo=UTC)
+
+    async def test_list_forwards_both_bounds(self, mock_ctx, mock_client):
+        """Both modified_date bounds produce a single DateFilter with both set."""
+        mock_client.conversations.list.return_value = []
+
+        await devrev_conversations_list(
+            mock_ctx,
+            modified_date_after="2025-01-01T00:00:00Z",
+            modified_date_before="2025-02-01T00:00:00Z",
+        )
+
+        request = self._call_request(mock_client)
+        assert request.modified_date is not None
+        assert request.modified_date.after is not None
+        assert request.modified_date.before is not None
+
+    async def test_list_without_dates_sets_no_filter(self, mock_ctx, mock_client):
+        """Omitting both date params leaves modified_date unset."""
+        mock_client.conversations.list.return_value = []
+
+        await devrev_conversations_list(mock_ctx)
+
+        request = self._call_request(mock_client)
+        assert request.modified_date is None
+
+    async def test_list_invalid_modified_date_after_raises(self, mock_ctx, mock_client):
+        """Malformed modified_date_after raises RuntimeError without calling SDK."""
+        with pytest.raises(RuntimeError, match="Invalid modified_date_after"):
+            await devrev_conversations_list(mock_ctx, modified_date_after="not-a-date")
+        mock_client.conversations.list.assert_not_called()
+
+    async def test_list_invalid_modified_date_before_raises(self, mock_ctx, mock_client):
+        """Malformed modified_date_before raises RuntimeError without calling SDK."""
+        with pytest.raises(RuntimeError, match="Invalid modified_date_before"):
+            await devrev_conversations_list(mock_ctx, modified_date_before="bogus")
+        mock_client.conversations.list.assert_not_called()
+
+    async def test_list_forwards_sort_by(self, mock_ctx, mock_client):
+        """sort_by is forwarded to the SDK untouched (SDK normalizes it)."""
+        mock_client.conversations.list.return_value = []
+
+        await devrev_conversations_list(mock_ctx, sort_by=["-modified_date"])
+
+        request = self._call_request(mock_client)
+        assert request.sort_by == ["-modified_date"]
+
+    async def test_list_sort_by_none_is_none(self, mock_ctx, mock_client):
+        """Omitting sort_by leaves it as None on the request."""
+        mock_client.conversations.list.return_value = []
+
+        await devrev_conversations_list(mock_ctx)
+
+        request = self._call_request(mock_client)
+        assert request.sort_by is None
+
+
+class TestConversationsListModifiedSinceTool:
+    """Tests for devrev_conversations_list_modified_since tool."""
+
+    async def test_parses_after_and_forwards(self, mock_ctx, mock_client):
+        """A valid ISO ``after`` is parsed and forwarded with optional limit."""
+        conv = _make_mock_conversation()
+        mock_client.conversations.list_modified_since.return_value = [conv]
+
+        result = await devrev_conversations_list_modified_since(
+            mock_ctx, after="2025-01-01T00:00:00Z", limit=5
+        )
+
+        assert result["count"] == 1
+        assert len(result["conversations"]) == 1
+        kwargs = mock_client.conversations.list_modified_since.call_args.kwargs
+        assert kwargs["after"] == datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+        assert kwargs["limit"] == 5
+
+    async def test_defaults_limit_to_none(self, mock_ctx, mock_client):
+        """Calling without an explicit limit forwards ``limit=None``."""
+        mock_client.conversations.list_modified_since.return_value = []
+
+        result = await devrev_conversations_list_modified_since(
+            mock_ctx, after="2025-03-01T00:00:00Z"
+        )
+
+        assert result["count"] == 0
+        assert result["conversations"] == []
+        kwargs = mock_client.conversations.list_modified_since.call_args.kwargs
+        assert kwargs["limit"] is None
+
+    async def test_invalid_after_raises_without_sdk_call(self, mock_ctx, mock_client):
+        """An unparseable ``after`` raises RuntimeError before any SDK call."""
+        with pytest.raises(RuntimeError, match="Invalid after"):
+            await devrev_conversations_list_modified_since(mock_ctx, after="nope")
+        mock_client.conversations.list_modified_since.assert_not_called()
+
+    async def test_sdk_error_is_wrapped(self, mock_ctx, mock_client):
+        """DevRevError from the SDK becomes a RuntimeError."""
+        mock_client.conversations.list_modified_since.side_effect = NotFoundError(
+            "not found", status_code=404
+        )
+
+        with pytest.raises(RuntimeError, match="Not found"):
+            await devrev_conversations_list_modified_since(mock_ctx, after="2025-01-01T00:00:00Z")

--- a/tests/unit/mcp/test_tools_works.py
+++ b/tests/unit/mcp/test_tools_works.py
@@ -1,5 +1,6 @@
 """Comprehensive tests for DevRev MCP works tools."""
 
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,11 +12,13 @@ from devrev_mcp.tools.works import (
     devrev_works_export,
     devrev_works_get,
     devrev_works_list,
+    devrev_works_list_created_since,
+    devrev_works_list_modified_since,
     devrev_works_update,
 )
 
 
-def _make_mock_work(data=None):
+def _make_mock_work(data: dict[str, str] | None = None) -> MagicMock:
     """Create a mock Work model with model_dump support."""
     default = {"id": "don:core:work/1", "title": "Test Work", "type": "ticket"}
     work = MagicMock()
@@ -248,3 +251,178 @@ class TestWorksExportTool:
         call_kwargs = mock_client.works.export.call_args.kwargs
         assert call_kwargs["type"] == [WorkType.ISSUE]
         assert call_kwargs["first"] == 50
+
+
+class TestWorksDocstringTerminology:
+    """Verify all works tool docstrings clarify the ticket/issue/task terminology."""
+
+    @pytest.mark.parametrize(
+        "tool",
+        [
+            devrev_works_list,
+            devrev_works_get,
+            devrev_works_create,
+            devrev_works_update,
+            devrev_works_delete,
+            devrev_works_count,
+            devrev_works_export,
+            devrev_works_list_modified_since,
+            devrev_works_list_created_since,
+        ],
+    )
+    def test_docstring_mentions_ticket_issue_task(self, tool):
+        """Each works tool docstring must reference tickets, issues, and tasks."""
+        doc = (tool.__doc__ or "").lower()
+        assert "ticket" in doc, f"{tool.__name__} docstring missing 'ticket'"
+        assert "issue" in doc, f"{tool.__name__} docstring missing 'issue'"
+        assert "task" in doc, f"{tool.__name__} docstring missing 'task'"
+
+
+class TestWorksListSortBy:
+    """Tests for sort_by forwarding on devrev_works_list."""
+
+    async def test_list_forwards_sort_by(self, mock_ctx, mock_client):
+        """sort_by is forwarded unchanged to the SDK."""
+        response = MagicMock()
+        response.works = []
+        response.next_cursor = None
+        mock_client.works.list.return_value = response
+
+        await devrev_works_list(mock_ctx, sort_by=["modified_date:desc", "-created_date"])
+        call_kwargs = mock_client.works.list.call_args.kwargs
+        assert call_kwargs["sort_by"] == ["modified_date:desc", "-created_date"]
+
+    async def test_list_sort_by_defaults_to_none(self, mock_ctx, mock_client):
+        """sort_by defaults to None and is forwarded as None."""
+        response = MagicMock()
+        response.works = []
+        response.next_cursor = None
+        mock_client.works.list.return_value = response
+
+        await devrev_works_list(mock_ctx)
+        call_kwargs = mock_client.works.list.call_args.kwargs
+        assert call_kwargs["sort_by"] is None
+
+
+class TestWorksExportSortBy:
+    """Tests for sort_by forwarding on devrev_works_export."""
+
+    async def test_export_forwards_sort_by(self, mock_ctx, mock_client):
+        """sort_by is forwarded unchanged to the SDK."""
+        mock_client.works.export.return_value = []
+
+        await devrev_works_export(mock_ctx, sort_by=["created_date:asc"])
+        call_kwargs = mock_client.works.export.call_args.kwargs
+        assert call_kwargs["sort_by"] == ["created_date:asc"]
+
+    async def test_export_sort_by_defaults_to_none(self, mock_ctx, mock_client):
+        """sort_by defaults to None and is forwarded as None."""
+        mock_client.works.export.return_value = []
+
+        await devrev_works_export(mock_ctx)
+        call_kwargs = mock_client.works.export.call_args.kwargs
+        assert call_kwargs["sort_by"] is None
+
+
+class TestWorksListModifiedSince:
+    """Tests for devrev_works_list_modified_since tool."""
+
+    async def test_parses_iso_with_z_suffix(self, mock_ctx, mock_client):
+        """A trailing 'Z' is accepted and converted to a UTC datetime."""
+        mock_client.works.list_modified_since.return_value = []
+
+        await devrev_works_list_modified_since(mock_ctx, after="2024-01-15T12:34:56Z")
+        args, _ = mock_client.works.list_modified_since.call_args
+        assert args[0] == datetime(2024, 1, 15, 12, 34, 56, tzinfo=UTC)
+
+    async def test_parses_iso_with_offset(self, mock_ctx, mock_client):
+        """An explicit UTC offset is accepted."""
+        mock_client.works.list_modified_since.return_value = []
+
+        await devrev_works_list_modified_since(mock_ctx, after="2024-01-15T12:34:56+00:00")
+        args, _ = mock_client.works.list_modified_since.call_args
+        assert args[0] == datetime(2024, 1, 15, 12, 34, 56, tzinfo=UTC)
+
+    async def test_invalid_iso_raises_runtime_error(self, mock_ctx, mock_client):
+        """Invalid ISO input raises RuntimeError with a clear message."""
+        with pytest.raises(RuntimeError, match="Invalid after format"):
+            await devrev_works_list_modified_since(mock_ctx, after="not-a-date")
+        mock_client.works.list_modified_since.assert_not_called()
+
+    async def test_forwards_filter_kwargs(self, mock_ctx, mock_client):
+        """type, owned_by, applies_to_part, and limit are forwarded."""
+        mock_client.works.list_modified_since.return_value = []
+
+        await devrev_works_list_modified_since(
+            mock_ctx,
+            after="2024-01-15T00:00:00Z",
+            type=["ticket", "issue"],
+            owned_by=["u1"],
+            applies_to_part=["p1"],
+            limit=500,
+        )
+        from devrev.models.works import WorkType
+
+        call_kwargs = mock_client.works.list_modified_since.call_args.kwargs
+        assert call_kwargs["type"] == [WorkType.TICKET, WorkType.ISSUE]
+        assert call_kwargs["owned_by"] == ["u1"]
+        assert call_kwargs["applies_to_part"] == ["p1"]
+        assert call_kwargs["limit"] == 500
+
+    async def test_returns_paginated_shape(self, mock_ctx, mock_client):
+        """Returns a dict with count and works (no next_cursor)."""
+        work = _make_mock_work({"id": "w1"})
+        mock_client.works.list_modified_since.return_value = [work]
+
+        result = await devrev_works_list_modified_since(mock_ctx, after="2024-01-15T00:00:00Z")
+        assert result["count"] == 1
+        assert result["works"][0]["id"] == "w1"
+        assert "next_cursor" not in result
+
+
+class TestWorksListCreatedSince:
+    """Tests for devrev_works_list_created_since tool."""
+
+    async def test_parses_iso_with_z_suffix(self, mock_ctx, mock_client):
+        """A trailing 'Z' is accepted and converted to a UTC datetime."""
+        mock_client.works.list_created_since.return_value = []
+
+        await devrev_works_list_created_since(mock_ctx, after="2024-02-01T00:00:00Z")
+        args, _ = mock_client.works.list_created_since.call_args
+        assert args[0] == datetime(2024, 2, 1, 0, 0, 0, tzinfo=UTC)
+
+    async def test_invalid_iso_raises_runtime_error(self, mock_ctx, mock_client):
+        """Invalid ISO input raises RuntimeError with a clear message."""
+        with pytest.raises(RuntimeError, match="Invalid after format"):
+            await devrev_works_list_created_since(mock_ctx, after="bogus")
+        mock_client.works.list_created_since.assert_not_called()
+
+    async def test_forwards_filter_kwargs(self, mock_ctx, mock_client):
+        """type, owned_by, applies_to_part, and limit are forwarded."""
+        mock_client.works.list_created_since.return_value = []
+
+        await devrev_works_list_created_since(
+            mock_ctx,
+            after="2024-02-01T00:00:00Z",
+            type=["task"],
+            owned_by=["u2"],
+            applies_to_part=["p2"],
+            limit=10,
+        )
+        from devrev.models.works import WorkType
+
+        call_kwargs = mock_client.works.list_created_since.call_args.kwargs
+        assert call_kwargs["type"] == [WorkType.TASK]
+        assert call_kwargs["owned_by"] == ["u2"]
+        assert call_kwargs["applies_to_part"] == ["p2"]
+        assert call_kwargs["limit"] == 10
+
+    async def test_returns_paginated_shape(self, mock_ctx, mock_client):
+        """Returns a dict with count and works (no next_cursor)."""
+        work = _make_mock_work({"id": "w9"})
+        mock_client.works.list_created_since.return_value = [work]
+
+        result = await devrev_works_list_created_since(mock_ctx, after="2024-02-01T00:00:00Z")
+        assert result["count"] == 1
+        assert result["works"][0]["id"] == "w9"
+        assert "next_cursor" not in result

--- a/tests/unit/services/test_conversations.py
+++ b/tests/unit/services/test_conversations.py
@@ -348,6 +348,66 @@ class TestListModifiedSince:
         payload = mock_http_client.post.call_args[1]["data"]
         assert payload["limit"] == 3
 
+    def test_limit_above_server_max_clamped_to_100(self, mock_http_client: MagicMock) -> None:
+        """limit=200, page_size=None must never send limit>100 per page."""
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        page1_convs = [
+            self._make_conv(f"a{i}", after + timedelta(days=200 - i)) for i in range(100)
+        ]
+        page2_convs = [
+            self._make_conv(f"b{i}", after + timedelta(days=100 - i)) for i in range(100)
+        ]
+        mock_http_client.post.side_effect = [
+            create_mock_response({"conversations": page1_convs, "next_cursor": "cursor-2"}),
+            create_mock_response({"conversations": page2_convs, "next_cursor": None}),
+        ]
+
+        service = ConversationsService(mock_http_client)
+        result = service.list_modified_since(after, limit=200)
+
+        assert len(result) == 200
+        assert mock_http_client.post.call_count == 2
+        for call in mock_http_client.post.call_args_list:
+            payload = call[1]["data"]
+            assert payload["limit"] is not None
+            assert payload["limit"] <= 100
+
+    def test_small_limit_below_server_max_passed_through(self, mock_http_client: MagicMock) -> None:
+        """limit=50, page_size=None sends the small limit directly."""
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        mock_http_client.post.return_value = create_mock_response(
+            {"conversations": [], "next_cursor": None}
+        )
+
+        service = ConversationsService(mock_http_client)
+        service.list_modified_since(after, limit=50)
+
+        payload = mock_http_client.post.call_args[1]["data"]
+        assert payload["limit"] == 50
+
+    def test_limit_spanning_multiple_pages_clamps_each_request(
+        self, mock_http_client: MagicMock
+    ) -> None:
+        """limit=300, page_size=None keeps each per-page limit at <=100."""
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        page1 = [self._make_conv(f"a{i}", after + timedelta(days=300 - i)) for i in range(100)]
+        page2 = [self._make_conv(f"b{i}", after + timedelta(days=200 - i)) for i in range(100)]
+        page3 = [self._make_conv(f"c{i}", after + timedelta(days=100 - i)) for i in range(100)]
+        mock_http_client.post.side_effect = [
+            create_mock_response({"conversations": page1, "next_cursor": "c2"}),
+            create_mock_response({"conversations": page2, "next_cursor": "c3"}),
+            create_mock_response({"conversations": page3, "next_cursor": None}),
+        ]
+
+        service = ConversationsService(mock_http_client)
+        result = service.list_modified_since(after, limit=300)
+
+        assert len(result) == 300
+        assert mock_http_client.post.call_count == 3
+        payloads = [c[1]["data"] for c in mock_http_client.post.call_args_list]
+        assert all(p["limit"] is not None and p["limit"] <= 100 for p in payloads)
+        assert payloads[2]["limit"] == 100
+
 
 class TestAsyncListModifiedSince:
     """Tests for AsyncConversationsService.list_modified_since."""
@@ -404,3 +464,85 @@ class TestAsyncListModifiedSince:
 
         assert [c.id for c in result] == ["a", "b"]
         assert mock_async_http_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_async_limit_above_server_max_clamped_to_100(
+        self, mock_async_http_client: AsyncMock
+    ) -> None:
+        """Async: limit=200, page_size=None must never send limit>100 per page."""
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        page1_convs = [
+            {
+                "id": f"a{i}",
+                "modified_date": (after + timedelta(days=200 - i)).isoformat(),
+            }
+            for i in range(100)
+        ]
+        page2_convs = [
+            {
+                "id": f"b{i}",
+                "modified_date": (after + timedelta(days=100 - i)).isoformat(),
+            }
+            for i in range(100)
+        ]
+        mock_async_http_client.post.side_effect = [
+            create_mock_response({"conversations": page1_convs, "next_cursor": "cursor-2"}),
+            create_mock_response({"conversations": page2_convs, "next_cursor": None}),
+        ]
+
+        service = AsyncConversationsService(mock_async_http_client)
+        result = await service.list_modified_since(after, limit=200)
+
+        assert len(result) == 200
+        assert mock_async_http_client.post.call_count == 2
+        for call in mock_async_http_client.post.call_args_list:
+            payload = call[1]["data"]
+            assert payload["limit"] is not None
+            assert payload["limit"] <= 100
+
+    @pytest.mark.asyncio
+    async def test_async_small_limit_passed_through(
+        self, mock_async_http_client: AsyncMock
+    ) -> None:
+        """Async: limit=50, page_size=None sends the small limit directly."""
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        mock_async_http_client.post.return_value = create_mock_response(
+            {"conversations": [], "next_cursor": None}
+        )
+
+        service = AsyncConversationsService(mock_async_http_client)
+        await service.list_modified_since(after, limit=50)
+
+        payload = mock_async_http_client.post.call_args[1]["data"]
+        assert payload["limit"] == 50
+
+    @pytest.mark.asyncio
+    async def test_async_limit_spanning_multiple_pages_clamps_each_request(
+        self, mock_async_http_client: AsyncMock
+    ) -> None:
+        """Async: limit=300, page_size=None keeps each per-page limit at <=100."""
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+
+        def _page(prefix: str, day_start: int) -> list[dict[str, Any]]:
+            return [
+                {
+                    "id": f"{prefix}{i}",
+                    "modified_date": (after + timedelta(days=day_start - i)).isoformat(),
+                }
+                for i in range(100)
+            ]
+
+        mock_async_http_client.post.side_effect = [
+            create_mock_response({"conversations": _page("a", 300), "next_cursor": "c2"}),
+            create_mock_response({"conversations": _page("b", 200), "next_cursor": "c3"}),
+            create_mock_response({"conversations": _page("c", 100), "next_cursor": None}),
+        ]
+
+        service = AsyncConversationsService(mock_async_http_client)
+        result = await service.list_modified_since(after, limit=300)
+
+        assert len(result) == 300
+        assert mock_async_http_client.post.call_count == 3
+        payloads = [c[1]["data"] for c in mock_async_http_client.post.call_args_list]
+        assert all(p["limit"] is not None and p["limit"] <= 100 for p in payloads)
+        assert payloads[2]["limit"] == 100

--- a/tests/unit/services/test_conversations.py
+++ b/tests/unit/services/test_conversations.py
@@ -189,10 +189,14 @@ class TestNormalizeSortBy:
     def test_preserves_explicit_direction(self) -> None:
         assert _normalize_sort_by(["modified_date:desc"]) == ["modified_date:desc"]
 
+    def test_dash_prefix_becomes_desc(self) -> None:
+        assert _normalize_sort_by(["-modified_date"]) == ["modified_date:desc"]
+
     def test_mixed_entries(self) -> None:
-        assert _normalize_sort_by(["modified_date:desc", "created_date"]) == [
+        assert _normalize_sort_by(["modified_date:desc", "created_date", "-priority"]) == [
             "modified_date:desc",
             "created_date:asc",
+            "priority:desc",
         ]
 
 
@@ -215,6 +219,37 @@ class TestConversationsListRequestModel:
         payload = request.model_dump(exclude_none=True, by_alias=True, mode="json")
         assert isinstance(payload["modified_date"]["after"], str)
         assert payload["modified_date"]["after"].startswith("2024-01-15T10:00:00")
+
+
+class TestConversationsServiceListSortByNormalization:
+    """Tests that ConversationsService.list normalizes sort_by before sending."""
+
+    def test_list_normalizes_dash_prefix_sort_by_in_payload(
+        self, mock_http_client: MagicMock
+    ) -> None:
+        mock_http_client.post.return_value = create_mock_response(
+            {"conversations": [], "next_cursor": None}
+        )
+
+        service = ConversationsService(mock_http_client)
+        service.list(ConversationsListRequest(sort_by=["-modified_date"]))
+
+        payload = mock_http_client.post.call_args[1]["data"]
+        assert payload["sort_by"] == ["modified_date:desc"]
+
+    @pytest.mark.asyncio
+    async def test_async_list_normalizes_dash_prefix_sort_by_in_payload(
+        self, mock_async_http_client: AsyncMock
+    ) -> None:
+        mock_async_http_client.post.return_value = create_mock_response(
+            {"conversations": [], "next_cursor": None}
+        )
+
+        service = AsyncConversationsService(mock_async_http_client)
+        await service.list(ConversationsListRequest(sort_by=["-modified_date"]))
+
+        payload = mock_async_http_client.post.call_args[1]["data"]
+        assert payload["sort_by"] == ["modified_date:desc"]
 
 
 class TestListModifiedSince:

--- a/tests/unit/services/test_conversations.py
+++ b/tests/unit/services/test_conversations.py
@@ -1,8 +1,12 @@
 """Unit tests for ConversationsService."""
 
+from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+from devrev.models.base import DateFilter
 from devrev.models.conversations import (
     Conversation,
     ConversationExportItem,
@@ -13,7 +17,11 @@ from devrev.models.conversations import (
     ConversationsListRequest,
     ConversationsUpdateRequest,
 )
-from devrev.services.conversations import ConversationsService
+from devrev.services.conversations import (
+    AsyncConversationsService,
+    ConversationsService,
+    _normalize_sort_by,
+)
 
 from .conftest import create_mock_response
 
@@ -164,3 +172,200 @@ class TestConversationsService:
 
         assert len(result) == 1
         mock_http_client.post.assert_called_once()
+
+
+class TestNormalizeSortBy:
+    """Tests for the _normalize_sort_by helper."""
+
+    def test_returns_none_for_none(self) -> None:
+        assert _normalize_sort_by(None) is None
+
+    def test_returns_empty_list_for_empty_input(self) -> None:
+        assert _normalize_sort_by([]) == []
+
+    def test_adds_asc_default_for_bare_field_name(self) -> None:
+        assert _normalize_sort_by(["modified_date"]) == ["modified_date:asc"]
+
+    def test_preserves_explicit_direction(self) -> None:
+        assert _normalize_sort_by(["modified_date:desc"]) == ["modified_date:desc"]
+
+    def test_mixed_entries(self) -> None:
+        assert _normalize_sort_by(["modified_date:desc", "created_date"]) == [
+            "modified_date:desc",
+            "created_date:asc",
+        ]
+
+
+class TestConversationsListRequestModel:
+    """Tests for the extended ConversationsListRequest model."""
+
+    def test_accepts_modified_date_and_sort_by(self) -> None:
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        request = ConversationsListRequest(
+            modified_date=DateFilter(after=after),
+            sort_by=["modified_date:desc"],
+        )
+        assert request.modified_date is not None
+        assert request.modified_date.after == after
+        assert request.sort_by == ["modified_date:desc"]
+
+    def test_payload_serializes_datetime_as_iso_string(self) -> None:
+        after = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        request = ConversationsListRequest(modified_date=DateFilter(after=after))
+        payload = request.model_dump(exclude_none=True, by_alias=True, mode="json")
+        assert isinstance(payload["modified_date"]["after"], str)
+        assert payload["modified_date"]["after"].startswith("2024-01-15T10:00:00")
+
+
+class TestListModifiedSince:
+    """Tests for ConversationsService.list_modified_since."""
+
+    def _make_conv(self, conv_id: str, modified: datetime | None) -> dict[str, Any]:
+        return {
+            "id": conv_id,
+            "modified_date": modified.isoformat() if modified else None,
+        }
+
+    def test_forwards_modified_date_and_sort_by_in_payload(
+        self, mock_http_client: MagicMock
+    ) -> None:
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        mock_http_client.post.return_value = create_mock_response(
+            {"conversations": [], "next_cursor": None}
+        )
+
+        service = ConversationsService(mock_http_client)
+        service.list_modified_since(after)
+
+        payload = mock_http_client.post.call_args[1]["data"]
+        # Pydantic mode="json" serializes datetimes as JSON-safe ISO strings.
+        assert isinstance(payload["modified_date"]["after"], str)
+        assert payload["modified_date"]["after"].startswith("2024-01-01T00:00:00")
+        assert payload["sort_by"] == ["modified_date:desc"]
+
+    def test_respects_overall_limit(self, mock_http_client: MagicMock) -> None:
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        convs = [
+            self._make_conv("a", after + timedelta(days=3)),
+            self._make_conv("b", after + timedelta(days=2)),
+            self._make_conv("c", after + timedelta(days=1)),
+        ]
+        mock_http_client.post.return_value = create_mock_response(
+            {"conversations": convs, "next_cursor": "next"}
+        )
+
+        service = ConversationsService(mock_http_client)
+        result = service.list_modified_since(after, limit=2)
+
+        assert len(result) == 2
+        assert [c.id for c in result] == ["a", "b"]
+        # Single request; limit reached within first page, no follow-up call.
+        assert mock_http_client.post.call_count == 1
+
+    def test_paginates_via_cursor(self, mock_http_client: MagicMock) -> None:
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        page1 = {
+            "conversations": [self._make_conv("a", after + timedelta(days=5))],
+            "next_cursor": "cursor-2",
+        }
+        page2 = {
+            "conversations": [self._make_conv("b", after + timedelta(days=4))],
+            "next_cursor": None,
+        }
+        mock_http_client.post.side_effect = [
+            create_mock_response(page1),
+            create_mock_response(page2),
+        ]
+
+        service = ConversationsService(mock_http_client)
+        result = service.list_modified_since(after)
+
+        assert [c.id for c in result] == ["a", "b"]
+        assert mock_http_client.post.call_count == 2
+        second_payload = mock_http_client.post.call_args_list[1][1]["data"]
+        assert second_payload["cursor"] == "cursor-2"
+
+    def test_stops_when_cutoff_is_passed(self, mock_http_client: MagicMock) -> None:
+        after = datetime(2024, 6, 1, tzinfo=UTC)
+        convs = [
+            self._make_conv("a", after + timedelta(days=1)),
+            self._make_conv("b", after - timedelta(days=1)),  # before cutoff
+            self._make_conv("c", after - timedelta(days=2)),
+        ]
+        mock_http_client.post.return_value = create_mock_response(
+            {"conversations": convs, "next_cursor": "next"}
+        )
+
+        service = ConversationsService(mock_http_client)
+        result = service.list_modified_since(after)
+
+        assert [c.id for c in result] == ["a"]
+
+    def test_page_size_capped_by_remaining_limit(self, mock_http_client: MagicMock) -> None:
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        mock_http_client.post.return_value = create_mock_response(
+            {"conversations": [], "next_cursor": None}
+        )
+
+        service = ConversationsService(mock_http_client)
+        service.list_modified_since(after, limit=3, page_size=10)
+
+        payload = mock_http_client.post.call_args[1]["data"]
+        assert payload["limit"] == 3
+
+
+class TestAsyncListModifiedSince:
+    """Tests for AsyncConversationsService.list_modified_since."""
+
+    @pytest.mark.asyncio
+    async def test_async_forwards_payload(self, mock_async_http_client: AsyncMock) -> None:
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        mock_async_http_client.post.return_value = create_mock_response(
+            {"conversations": [], "next_cursor": None}
+        )
+
+        service = AsyncConversationsService(mock_async_http_client)
+        await service.list_modified_since(after)
+
+        payload = mock_async_http_client.post.call_args[1]["data"]
+        assert isinstance(payload["modified_date"]["after"], str)
+        assert payload["modified_date"]["after"].startswith("2024-01-01T00:00:00")
+        assert payload["sort_by"] == ["modified_date:desc"]
+
+    @pytest.mark.asyncio
+    async def test_async_respects_limit_and_pagination(
+        self, mock_async_http_client: AsyncMock
+    ) -> None:
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        page1 = {
+            "conversations": [
+                {
+                    "id": "a",
+                    "modified_date": (after + timedelta(days=5)).isoformat(),
+                },
+            ],
+            "next_cursor": "cursor-2",
+        }
+        page2 = {
+            "conversations": [
+                {
+                    "id": "b",
+                    "modified_date": (after + timedelta(days=4)).isoformat(),
+                },
+                {
+                    "id": "c",
+                    "modified_date": (after + timedelta(days=3)).isoformat(),
+                },
+            ],
+            "next_cursor": None,
+        }
+        mock_async_http_client.post.side_effect = [
+            create_mock_response(page1),
+            create_mock_response(page2),
+        ]
+
+        service = AsyncConversationsService(mock_async_http_client)
+        result = await service.list_modified_since(after, limit=2)
+
+        assert [c.id for c in result] == ["a", "b"]
+        assert mock_async_http_client.post.call_count == 2

--- a/tests/unit/services/test_works.py
+++ b/tests/unit/services/test_works.py
@@ -405,6 +405,83 @@ class TestListCreatedSince:
         assert mock_http_client.post.call_count == 1
 
 
+class TestListSincePageLimitClamp:
+    """``_list_since`` must never send ``limit>100`` to the server."""
+
+    def test_page_size_above_server_max_clamped_to_100(self, mock_http_client: MagicMock) -> None:
+        """``page_size=200`` must be clamped to 100 in the outgoing request."""
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        mock_http_client.post.return_value = create_mock_response(
+            {"works": [], "next_cursor": None}
+        )
+
+        service = WorksService(mock_http_client)
+        service.list_modified_since(after, page_size=200)
+
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs["data"]["limit"] == 100
+
+    def test_limit_above_server_max_clamped_to_100(self, mock_http_client: MagicMock) -> None:
+        """``limit=200, page_size=None`` must never send ``limit>100`` per page."""
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        page1_works = [
+            _work_record(
+                f"don:core:work:a{i}",
+                "modified_date",
+                f"2024-07-{(i % 28) + 1:02d}T00:00:00Z",
+            )
+            for i in range(100)
+        ]
+        page2_works = [
+            _work_record(
+                f"don:core:work:b{i}",
+                "modified_date",
+                f"2024-06-{(i % 28) + 1:02d}T00:00:00Z",
+            )
+            for i in range(100)
+        ]
+        mock_http_client.post.side_effect = [
+            create_mock_response(_work_page(page1_works, next_cursor="cursor-2")),
+            create_mock_response(_work_page(page2_works, next_cursor=None)),
+        ]
+
+        service = WorksService(mock_http_client)
+        results = service.list_modified_since(after, limit=200)
+
+        assert len(results) == 200
+        assert mock_http_client.post.call_count == 2
+        for call in mock_http_client.post.call_args_list:
+            payload = call[1]["data"]
+            assert payload["limit"] is not None
+            assert payload["limit"] <= 100
+
+    def test_small_limit_below_server_max_passed_through(self, mock_http_client: MagicMock) -> None:
+        """``limit=50, page_size=None`` sends the small limit directly."""
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        mock_http_client.post.return_value = create_mock_response(
+            {"works": [], "next_cursor": None}
+        )
+
+        service = WorksService(mock_http_client)
+        service.list_modified_since(after, limit=50)
+
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs["data"]["limit"] == 50
+
+    def test_list_created_since_page_size_clamped_smoke(self, mock_http_client: MagicMock) -> None:
+        """Smoke test: shared helper path clamps for ``list_created_since`` too."""
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        mock_http_client.post.return_value = create_mock_response(
+            {"works": [], "next_cursor": None}
+        )
+
+        service = WorksService(mock_http_client)
+        service.list_created_since(after, page_size=200)
+
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs["data"]["limit"] == 100
+
+
 class TestAsyncListSince:
     """Async variants for ``list_modified_since`` / ``list_created_since``."""
 
@@ -461,6 +538,72 @@ class TestAsyncListSince:
 
         _, kwargs = mock_async_client.post.call_args
         assert kwargs["data"]["sort_by"] == ["modified_date:desc"]
+
+    @pytest.mark.asyncio
+    async def test_async_page_size_above_server_max_clamped_to_100(self) -> None:
+        """Async: ``page_size=200`` must be clamped to 100 per page."""
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        mock_async_client = AsyncMock()
+        mock_async_client.post.return_value = create_mock_response(
+            {"works": [], "next_cursor": None}
+        )
+
+        service = AsyncWorksService(mock_async_client)
+        await service.list_modified_since(after, page_size=200)
+
+        _, kwargs = mock_async_client.post.call_args
+        assert kwargs["data"]["limit"] == 100
+
+    @pytest.mark.asyncio
+    async def test_async_limit_above_server_max_clamped_to_100(self) -> None:
+        """Async: ``limit=200, page_size=None`` must never send ``limit>100`` per page."""
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        page1_works = [
+            _work_record(
+                f"don:core:work:a{i}",
+                "modified_date",
+                f"2024-07-{(i % 28) + 1:02d}T00:00:00Z",
+            )
+            for i in range(100)
+        ]
+        page2_works = [
+            _work_record(
+                f"don:core:work:b{i}",
+                "modified_date",
+                f"2024-06-{(i % 28) + 1:02d}T00:00:00Z",
+            )
+            for i in range(100)
+        ]
+        mock_async_client = AsyncMock()
+        mock_async_client.post.side_effect = [
+            create_mock_response(_work_page(page1_works, next_cursor="cursor-2")),
+            create_mock_response(_work_page(page2_works, next_cursor=None)),
+        ]
+
+        service = AsyncWorksService(mock_async_client)
+        results = await service.list_modified_since(after, limit=200)
+
+        assert len(results) == 200
+        assert mock_async_client.post.call_count == 2
+        for call in mock_async_client.post.call_args_list:
+            payload = call[1]["data"]
+            assert payload["limit"] is not None
+            assert payload["limit"] <= 100
+
+    @pytest.mark.asyncio
+    async def test_async_small_limit_passed_through(self) -> None:
+        """Async: ``limit=50, page_size=None`` sends the small limit directly."""
+        after = datetime(2024, 1, 1, tzinfo=UTC)
+        mock_async_client = AsyncMock()
+        mock_async_client.post.return_value = create_mock_response(
+            {"works": [], "next_cursor": None}
+        )
+
+        service = AsyncWorksService(mock_async_client)
+        await service.list_modified_since(after, limit=50)
+
+        _, kwargs = mock_async_client.post.call_args
+        assert kwargs["data"]["limit"] == 50
 
 
 class TestIsBeforeCutoffHelper:

--- a/tests/unit/services/test_works.py
+++ b/tests/unit/services/test_works.py
@@ -1,7 +1,8 @@
 """Unit tests for WorksService."""
 
+from datetime import UTC, datetime
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -12,7 +13,7 @@ from devrev.models.works import (
     WorksListResponse,
     WorkType,
 )
-from devrev.services.works import WorksService
+from devrev.services.works import AsyncWorksService, WorksService, _normalize_sort_by
 
 
 def create_mock_response(data: dict[str, Any], status_code: int = 200) -> MagicMock:
@@ -207,3 +208,251 @@ class TestWorksService:
 
         assert isinstance(result, Work)
         assert result.applies_to_part == "don:core:dvrv-us-1:devo/org123:product/1"
+
+
+def _work_page(works: list[dict[str, Any]], next_cursor: str | None = None) -> dict[str, Any]:
+    """Build a works.list response payload for mocking."""
+    return {"works": works, "next_cursor": next_cursor}
+
+
+def _work_record(work_id: str, timestamp_field: str, timestamp: str) -> dict[str, Any]:
+    """Build a single work dict with a specific timestamp field set."""
+    return {
+        "id": work_id,
+        "type": "issue",
+        "display_id": work_id.split(":")[-1],
+        "title": f"Work {work_id}",
+        timestamp_field: timestamp,
+    }
+
+
+class TestNormalizeSortBy:
+    """Tests for the ``_normalize_sort_by`` helper."""
+
+    def test_none_passes_through(self) -> None:
+        assert _normalize_sort_by(None) is None
+
+    def test_empty_list(self) -> None:
+        assert _normalize_sort_by([]) == []
+
+    def test_dash_prefix_becomes_desc(self) -> None:
+        assert _normalize_sort_by(["-modified_date"]) == ["modified_date:desc"]
+
+    def test_bare_field_becomes_asc(self) -> None:
+        assert _normalize_sort_by(["modified_date"]) == ["modified_date:asc"]
+
+    def test_server_form_passes_through(self) -> None:
+        assert _normalize_sort_by(["modified_date:desc"]) == ["modified_date:desc"]
+        assert _normalize_sort_by(["created_date:asc"]) == ["created_date:asc"]
+
+    def test_mixed_inputs(self) -> None:
+        assert _normalize_sort_by(["-modified_date", "created_date:asc", "title"]) == [
+            "modified_date:desc",
+            "created_date:asc",
+            "title:asc",
+        ]
+
+
+class TestWorksServiceSortNormalization:
+    """Sort normalization is applied inside list() and export() requests."""
+
+    def test_list_normalizes_dash_form(
+        self, mock_http_client: MagicMock, sample_work_data: dict[str, Any]
+    ) -> None:
+        mock_http_client.post.return_value = create_mock_response(_work_page([sample_work_data]))
+        service = WorksService(mock_http_client)
+        service.list(sort_by=["-modified_date"])
+
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs["data"]["sort_by"] == ["modified_date:desc"]
+
+    def test_list_preserves_server_form(
+        self, mock_http_client: MagicMock, sample_work_data: dict[str, Any]
+    ) -> None:
+        mock_http_client.post.return_value = create_mock_response(_work_page([sample_work_data]))
+        service = WorksService(mock_http_client)
+        service.list(sort_by=["modified_date:desc"])
+
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs["data"]["sort_by"] == ["modified_date:desc"]
+
+    def test_export_normalizes_sort_by(
+        self, mock_http_client: MagicMock, sample_work_data: dict[str, Any]
+    ) -> None:
+        mock_http_client.post.return_value = create_mock_response({"works": [sample_work_data]})
+        service = WorksService(mock_http_client)
+        service.export(sort_by=["-created_date"])
+
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs["data"]["sort_by"] == ["created_date:desc"]
+
+
+class TestListModifiedSince:
+    """Tests for ``WorksService.list_modified_since``."""
+
+    def test_early_exit_when_record_older_than_after(self, mock_http_client: MagicMock) -> None:
+        """Iteration stops as soon as a record's modified_date < after."""
+        after = datetime(2024, 6, 1, tzinfo=UTC)
+        page1 = _work_page(
+            [
+                _work_record("don:core:work:1", "modified_date", "2024-07-01T00:00:00Z"),
+                _work_record("don:core:work:2", "modified_date", "2024-06-15T00:00:00Z"),
+                _work_record("don:core:work:3", "modified_date", "2024-05-15T00:00:00Z"),
+            ],
+            next_cursor="cursor-2",
+        )
+        mock_http_client.post.return_value = create_mock_response(page1)
+
+        service = WorksService(mock_http_client)
+        results = service.list_modified_since(after)
+
+        assert [w.id for w in results] == ["don:core:work:1", "don:core:work:2"]
+        # Only one HTTP request — early-exit prevented a second page fetch.
+        assert mock_http_client.post.call_count == 1
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs["data"]["sort_by"] == ["modified_date:desc"]
+
+    def test_paginates_until_cutoff_across_pages(self, mock_http_client: MagicMock) -> None:
+        after = datetime(2024, 6, 1, tzinfo=UTC)
+        page1 = _work_page(
+            [
+                _work_record("don:core:work:1", "modified_date", "2024-07-01T00:00:00Z"),
+                _work_record("don:core:work:2", "modified_date", "2024-06-15T00:00:00Z"),
+            ],
+            next_cursor="cursor-2",
+        )
+        page2 = _work_page(
+            [
+                _work_record("don:core:work:3", "modified_date", "2024-06-05T00:00:00Z"),
+                _work_record("don:core:work:4", "modified_date", "2024-05-15T00:00:00Z"),
+            ],
+            next_cursor="cursor-3",
+        )
+        mock_http_client.post.side_effect = [
+            create_mock_response(page1),
+            create_mock_response(page2),
+        ]
+
+        service = WorksService(mock_http_client)
+        results = service.list_modified_since(after)
+
+        assert [w.id for w in results] == [
+            "don:core:work:1",
+            "don:core:work:2",
+            "don:core:work:3",
+        ]
+        assert mock_http_client.post.call_count == 2
+
+    def test_respects_hard_limit(self, mock_http_client: MagicMock) -> None:
+        after = datetime(2020, 1, 1, tzinfo=UTC)
+        page = _work_page(
+            [
+                _work_record("don:core:work:1", "modified_date", "2024-07-01T00:00:00Z"),
+                _work_record("don:core:work:2", "modified_date", "2024-06-01T00:00:00Z"),
+                _work_record("don:core:work:3", "modified_date", "2024-05-01T00:00:00Z"),
+            ],
+            next_cursor="cursor-2",
+        )
+        mock_http_client.post.return_value = create_mock_response(page)
+
+        service = WorksService(mock_http_client)
+        results = service.list_modified_since(after, limit=2)
+
+        assert [w.id for w in results] == ["don:core:work:1", "don:core:work:2"]
+        assert mock_http_client.post.call_count == 1
+
+
+class TestListCreatedSince:
+    """Tests for ``WorksService.list_created_since``."""
+
+    def test_early_exit_and_sort_order(self, mock_http_client: MagicMock) -> None:
+        after = datetime(2024, 6, 1, tzinfo=UTC)
+        page = _work_page(
+            [
+                _work_record("don:core:work:1", "created_date", "2024-07-01T00:00:00Z"),
+                _work_record("don:core:work:2", "created_date", "2024-05-15T00:00:00Z"),
+            ]
+        )
+        mock_http_client.post.return_value = create_mock_response(page)
+
+        service = WorksService(mock_http_client)
+        results = service.list_created_since(after)
+
+        assert [w.id for w in results] == ["don:core:work:1"]
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs["data"]["sort_by"] == ["created_date:desc"]
+
+    def test_respects_hard_limit(self, mock_http_client: MagicMock) -> None:
+        after = datetime(2020, 1, 1, tzinfo=UTC)
+        page = _work_page(
+            [
+                _work_record("don:core:work:1", "created_date", "2024-07-01T00:00:00Z"),
+                _work_record("don:core:work:2", "created_date", "2024-06-01T00:00:00Z"),
+            ],
+            next_cursor="cursor-2",
+        )
+        mock_http_client.post.return_value = create_mock_response(page)
+
+        service = WorksService(mock_http_client)
+        results = service.list_created_since(after, limit=1)
+
+        assert [w.id for w in results] == ["don:core:work:1"]
+        assert mock_http_client.post.call_count == 1
+
+
+class TestAsyncListSince:
+    """Async variants for ``list_modified_since`` / ``list_created_since``."""
+
+    @pytest.mark.asyncio
+    async def test_async_list_modified_since_early_exit(self) -> None:
+        after = datetime(2024, 6, 1, tzinfo=UTC)
+        page = _work_page(
+            [
+                _work_record("don:core:work:1", "modified_date", "2024-07-01T00:00:00Z"),
+                _work_record("don:core:work:2", "modified_date", "2024-05-15T00:00:00Z"),
+            ],
+            next_cursor="cursor-next",
+        )
+        mock_async_client = AsyncMock()
+        mock_async_client.post.return_value = create_mock_response(page)
+
+        service = AsyncWorksService(mock_async_client)
+        results = await service.list_modified_since(after)
+
+        assert [w.id for w in results] == ["don:core:work:1"]
+        assert mock_async_client.post.call_count == 1
+        _, kwargs = mock_async_client.post.call_args
+        assert kwargs["data"]["sort_by"] == ["modified_date:desc"]
+
+    @pytest.mark.asyncio
+    async def test_async_list_created_since_respects_limit(self) -> None:
+        after = datetime(2020, 1, 1, tzinfo=UTC)
+        page = _work_page(
+            [
+                _work_record("don:core:work:1", "created_date", "2024-07-01T00:00:00Z"),
+                _work_record("don:core:work:2", "created_date", "2024-06-01T00:00:00Z"),
+                _work_record("don:core:work:3", "created_date", "2024-05-01T00:00:00Z"),
+            ],
+            next_cursor="cursor-next",
+        )
+        mock_async_client = AsyncMock()
+        mock_async_client.post.return_value = create_mock_response(page)
+
+        service = AsyncWorksService(mock_async_client)
+        results = await service.list_created_since(after, limit=2)
+
+        assert [w.id for w in results] == ["don:core:work:1", "don:core:work:2"]
+        assert mock_async_client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_async_list_normalizes_sort_by(self) -> None:
+        mock_async_client = AsyncMock()
+        mock_async_client.post.return_value = create_mock_response(
+            {"works": [], "next_cursor": None}
+        )
+
+        service = AsyncWorksService(mock_async_client)
+        await service.list(sort_by=["-modified_date"])
+
+        _, kwargs = mock_async_client.post.call_args
+        assert kwargs["data"]["sort_by"] == ["modified_date:desc"]

--- a/tests/unit/services/test_works.py
+++ b/tests/unit/services/test_works.py
@@ -13,7 +13,12 @@ from devrev.models.works import (
     WorksListResponse,
     WorkType,
 )
-from devrev.services.works import AsyncWorksService, WorksService, _normalize_sort_by
+from devrev.services.works import (
+    AsyncWorksService,
+    WorksService,
+    _is_before_cutoff,
+    _normalize_sort_by,
+)
 
 
 def create_mock_response(data: dict[str, Any], status_code: int = 200) -> MagicMock:
@@ -456,3 +461,103 @@ class TestAsyncListSince:
 
         _, kwargs = mock_async_client.post.call_args
         assert kwargs["data"]["sort_by"] == ["modified_date:desc"]
+
+
+class TestIsBeforeCutoffHelper:
+    """Tests for the ``_is_before_cutoff`` helper."""
+
+    def test_none_timestamp_returns_false(self) -> None:
+        cutoff = datetime(2024, 6, 1, tzinfo=UTC)
+        assert _is_before_cutoff(None, cutoff) is False
+
+    def test_aware_timestamp_before_cutoff(self) -> None:
+        cutoff = datetime(2024, 6, 1, tzinfo=UTC)
+        ts = datetime(2024, 5, 1, tzinfo=UTC)
+        assert _is_before_cutoff(ts, cutoff) is True
+
+    def test_aware_timestamp_after_cutoff(self) -> None:
+        cutoff = datetime(2024, 6, 1, tzinfo=UTC)
+        ts = datetime(2024, 7, 1, tzinfo=UTC)
+        assert _is_before_cutoff(ts, cutoff) is False
+
+    def test_naive_timestamp_with_aware_cutoff_returns_false(self) -> None:
+        """Incompatible tz-awareness must not raise; defers to server filter."""
+        cutoff = datetime(2024, 6, 1, tzinfo=UTC)
+        ts = datetime(2024, 5, 1)  # naive
+        assert _is_before_cutoff(ts, cutoff) is False
+
+    def test_aware_timestamp_with_naive_cutoff_returns_false(self) -> None:
+        """Incompatible tz-awareness must not raise; defers to server filter."""
+        cutoff = datetime(2024, 6, 1)  # naive
+        ts = datetime(2024, 5, 1, tzinfo=UTC)
+        assert _is_before_cutoff(ts, cutoff) is False
+
+
+class TestListSinceTimestampTypeSafety:
+    """``_list_since`` must not raise TypeError on mixed naive/aware timestamps."""
+
+    def test_naive_after_with_aware_record_timestamps_does_not_raise(
+        self, mock_http_client: MagicMock
+    ) -> None:
+        """A naive ``after`` with tz-aware record timestamps must not raise."""
+        after = datetime(2024, 6, 1)  # naive
+        page = _work_page(
+            [
+                _work_record("don:core:work:1", "modified_date", "2024-07-01T00:00:00Z"),
+                _work_record("don:core:work:2", "modified_date", "2024-05-15T00:00:00Z"),
+            ],
+            next_cursor=None,
+        )
+        mock_http_client.post.return_value = create_mock_response(page)
+
+        service = WorksService(mock_http_client)
+        # Must not raise TypeError. Both records are kept because the helper
+        # returns False on incompatible tz-awareness (server-side filter is
+        # authoritative).
+        results = service.list_modified_since(after)
+
+        assert [w.id for w in results] == ["don:core:work:1", "don:core:work:2"]
+        assert mock_http_client.post.call_count == 1
+
+    def test_aware_after_with_naive_record_timestamps_does_not_raise(
+        self, mock_http_client: MagicMock
+    ) -> None:
+        """A tz-aware ``after`` with naive record timestamps must not raise."""
+        after = datetime(2024, 6, 1, tzinfo=UTC)
+        # Timestamps without 'Z' / offset are parsed as naive datetimes.
+        page = _work_page(
+            [
+                _work_record("don:core:work:1", "modified_date", "2024-07-01T00:00:00"),
+                _work_record("don:core:work:2", "modified_date", "2024-05-15T00:00:00"),
+            ],
+            next_cursor=None,
+        )
+        mock_http_client.post.return_value = create_mock_response(page)
+
+        service = WorksService(mock_http_client)
+        results = service.list_modified_since(after)
+
+        assert [w.id for w in results] == ["don:core:work:1", "don:core:work:2"]
+        assert mock_http_client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_async_naive_after_with_aware_record_timestamps_does_not_raise(
+        self,
+    ) -> None:
+        """Async variant: naive ``after`` with aware record timestamps must not raise."""
+        after = datetime(2024, 6, 1)  # naive
+        page = _work_page(
+            [
+                _work_record("don:core:work:1", "created_date", "2024-07-01T00:00:00Z"),
+                _work_record("don:core:work:2", "created_date", "2024-05-15T00:00:00Z"),
+            ],
+            next_cursor=None,
+        )
+        mock_async_client = AsyncMock()
+        mock_async_client.post.return_value = create_mock_response(page)
+
+        service = AsyncWorksService(mock_async_client)
+        results = await service.list_created_since(after)
+
+        assert [w.id for w in results] == ["don:core:work:1", "don:core:work:2"]
+        assert mock_async_client.post.call_count == 1

--- a/tests/unit/test_base_service.py
+++ b/tests/unit/test_base_service.py
@@ -1,5 +1,7 @@
 """Unit tests for base service classes."""
 
+import json
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -13,6 +15,13 @@ class SampleRequest(BaseModel):
 
     name: str
     value: int | None = None
+
+
+class DateRequest(BaseModel):
+    """Request model with a datetime field for serialization tests."""
+
+    name: str
+    when: datetime | None = None
 
 
 class SampleResponse(BaseModel):
@@ -68,6 +77,23 @@ class TestBaseService:
         data = call_args[1]["data"]
         assert "value" not in data
 
+    def test_post_serializes_datetime_as_iso_string(
+        self, service: BaseService, mock_http_client: MagicMock
+    ) -> None:
+        """Ensure model_dump uses mode='json' so datetimes are JSON-safe."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "123", "name": "Test"}
+        mock_http_client.post.return_value = mock_response
+        when = datetime(2024, 1, 15, 12, 30, 45, tzinfo=UTC)
+        request = DateRequest(name="Test", when=when)
+        service._post("/test.endpoint", request, SampleResponse)
+        data = mock_http_client.post.call_args[1]["data"]
+        # Datetime must be serialized to an ISO 8601 string, not a datetime object.
+        assert isinstance(data["when"], str)
+        assert data["when"].startswith("2024-01-15T12:30:45")
+        # The payload must be JSON-serializable without custom encoders.
+        json.dumps(data)
+
     def test_get_with_response_type(
         self, service: BaseService, mock_http_client: MagicMock
     ) -> None:
@@ -118,6 +144,22 @@ class TestAsyncBaseService:
         result = await async_service._post("/async.endpoint", request, SampleResponse)
         assert isinstance(result, SampleResponse)
         assert result.id == "async123"
+
+    @pytest.mark.asyncio
+    async def test_async_post_serializes_datetime_as_iso_string(
+        self, async_service: AsyncBaseService, mock_async_http_client: MagicMock
+    ) -> None:
+        """Async _post must also serialize datetimes to JSON-safe strings."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "123", "name": "Test"}
+        mock_async_http_client.post.return_value = mock_response
+        when = datetime(2024, 1, 15, 12, 30, 45, tzinfo=UTC)
+        request = DateRequest(name="Test", when=when)
+        await async_service._post("/async.endpoint", request, SampleResponse)
+        data = mock_async_http_client.post.call_args[1]["data"]
+        assert isinstance(data["when"], str)
+        assert data["when"].startswith("2024-01-15T12:30:45")
+        json.dumps(data)
 
     @pytest.mark.asyncio
     async def test_async_get_with_response_type(


### PR DESCRIPTION
## Summary
Adds date-based listing support for `/works.list` and `/conversations.list` via client-side pagination, fixes a JSON-serialization bug in `BaseService._post`, and corrects `sort_by` normalization across both services. Also exposes the new capabilities through the MCP tool surface and documents the server-side limitations discovered during the Wave 0 spike.

Linear: CUSS-451

## What changed

### SDK (`src/devrev`)
- **NEW**: `WorksService.list_modified_since(after, *, type=None, owned_by=None, applies_to_part=None, limit=None, page_size=50)` (sync + async) — paginates server-side sorted desc, early-exits when `modified_date < after`.
- **NEW**: `WorksService.list_created_since(...)` — same shape, uses `created_date`.
- **NEW**: `ConversationsService.list_modified_since(after, *, limit=None, page_size=50)` — uses the server-side `modified_date` filter plus client-side pagination.
- **NEW** fields on `ConversationsListRequest`: `modified_date: DateFilter | None`, `sort_by: list[str] | None`.
- **sort_by normalization**: both services now accept `"-field"` shortcut and canonical `"field:desc"` / `"field:asc"` and normalize to the server-expected canonical form before sending.
- **BREAKING**: removed `created_date` / `modified_date` fields from `WorksListRequest` and `WorksExportRequest`. These never worked — the server returns 400 `bad-request.bad-request-field`. Callers must migrate to the new `list_modified_since` / `list_created_since` helpers. Passing the removed fields now raises `pydantic.ValidationError`.
- **Fix**: `BaseService._post` / `AsyncBaseService._post` now serialize with `model_dump(..., mode="json")`, so `DateFilter` (and any other `datetime`-bearing request model) no longer causes `TypeError` on the wire.

### MCP (`src/devrev_mcp`)
- **NEW tools**: `devrev_works_list_modified_since`, `devrev_works_list_created_since`, `devrev_conversations_list_modified_since`. All accept an ISO-8601 `after` (including trailing `Z`) and forward to the SDK.
- **NEW params**:
  - `devrev_works_list` / `devrev_works_export`: `sort_by: list[str] | None`.
  - `devrev_conversations_list`: `modified_date_after`, `modified_date_before`, `sort_by`.
- All works-tool docstrings now state "In DevRev, 'works' is the umbrella type covering tickets (customer support), issues (engineering), and tasks."

### Docs / metadata
- `docs/api/services/works.md`, `docs/api/services/conversations.md`, `docs/mcp/tools-reference.md`: new sections for the helpers, `sort_by` syntax, and terminology callout.
- `docs/changelog.md`: `[Unreleased]` with Added / Changed / Breaking / Fixed entries.
- `openapi-spec-corrections.yaml`: new Corrections #3, #4, #5 documenting that `/works.list` rejects `created_date`/`modified_date`, `/conversations.list` rejects `created_date`, and both endpoints require `"field:desc"` (not `"-field"`) syntax.

### Tests
- 1161 unit tests pass (SDK + MCP).
- New `tests/integration/test_date_filtering.py` with two read-only, token-gated integration tests (`limit=5`).

## Verification

| Check | Result |
|---|---|
| `uv run pytest tests/unit -q` | ✅ 1161 passed |
| `uv run pytest tests/integration/test_date_filtering.py` (no token) | ✅ 2 skipped, exit 0 |
| `uv run pytest tests/integration/test_date_filtering.py` (live token) | ✅ 2 passed |
| `uv run --extra docs mkdocs build --strict` | ✅ exit 0 |
| `uv run ruff check` / `ruff format --check` / `mypy` | ✅ clean |

## Migration notes

Any caller using the removed fields must switch:

```python
# Before
request = WorksListRequest(modified_date=DateFilter(after=cutoff), type=[WorkType.TICKET])
resp = client.works.list(request)

# After
records = client.works.list_modified_since(after=cutoff, type=[WorkType.TICKET], limit=100)
```

## Deployment / breaking-change note
The removal of `WorksListRequest.created_date` / `modified_date` is a breaking change at the Pydantic model level. It is being released as-is because those fields never produced a successful server response (server returned 400 every time), so no production caller can be relying on them returning data. They will, however, now fail fast at `ValidationError` rather than silently passing through an unsupported body. Release should tag a MAJOR version accordingly, or MINOR with a prominent breaking-change callout per the repo's conventions.
