### PR TITLE
feat(timeline): add visibility parameter to devrev_timeline_create (CUSS-569)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Timeline entry visibility** (CUSS-569) — `TimelineEntriesCreateRequest`
+  now accepts optional `visibility`, `private_to`, and `body_type` fields,
+  matching the DevRev REST `timeline-entries.create` contract. The
+  `devrev_timeline_create` MCP tool exposes a new `visibility` argument
+  (`external` / `internal` / `private` / `public`); when set to `internal`,
+  the entry is posted to the ticket's internal-discussion tab. A new
+  `TimelineEntryVisibility` enum is exported from `devrev.models`.
+
 ### Changed
 
 ### Fixed

--- a/src/devrev/models/__init__.py
+++ b/src/devrev/models/__init__.py
@@ -382,6 +382,7 @@ from devrev.models.timeline_entries import (
     TimelineEntriesUpdateResponse,
     TimelineEntry,
     TimelineEntryType,
+    TimelineEntryVisibility,
 )
 from devrev.models.timeline_events import (
     FieldChange,
@@ -817,6 +818,7 @@ __all__ = [
     # Timeline Entries
     "TimelineEntry",
     "TimelineEntryType",
+    "TimelineEntryVisibility",
     "TimelineEntriesCreateRequest",
     "TimelineEntriesCreateResponse",
     "TimelineEntriesGetRequest",

--- a/src/devrev/models/timeline_entries.py
+++ b/src/devrev/models/timeline_entries.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import Field
 
@@ -29,6 +30,24 @@ class TimelineEntryType(StrEnum):
     EVENT = "timeline_event"
 
 
+class TimelineEntryVisibility(StrEnum):
+    """Timeline entry visibility enumeration.
+
+    Mirrors the DevRev REST API ``timeline-entry-visibility`` enum:
+
+    - ``external``: visible to the Dev organization and Rev users (default).
+    - ``internal``: visible only within the Dev organization
+      (the "internal discussion" tab).
+    - ``private``: visible only to the creator (and ``private_to`` users).
+    - ``public``: visible to all.
+    """
+
+    EXTERNAL = "external"
+    INTERNAL = "internal"
+    PRIVATE = "private"
+    PUBLIC = "public"
+
+
 class TimelineEntry(DevRevResponseModel):
     """DevRev Timeline Entry model."""
 
@@ -49,6 +68,24 @@ class TimelineEntriesCreateRequest(DevRevBaseModel):
     object: str = Field(..., description="Parent object ID")
     type: TimelineEntryType = Field(..., description="Entry type")
     body: str | None = Field(default=None, description="Entry content")
+    visibility: TimelineEntryVisibility | None = Field(
+        default=None,
+        description=(
+            "Entry visibility. If unset, the server default ('external') is used. "
+            "Use 'internal' to post to the internal-discussion tab."
+        ),
+    )
+    private_to: list[str] | None = Field(
+        default=None,
+        description=(
+            "If visibility is 'private', the user IDs the entry is private to. "
+            "The creator is always implicitly included."
+        ),
+    )
+    body_type: Literal["data", "snap_kit", "snap_widget", "text"] | None = Field(
+        default=None,
+        description="Body type for timeline_comment entries (default: text).",
+    )
 
 
 class TimelineEntriesGetRequest(DevRevBaseModel):

--- a/src/devrev_mcp/tools/timeline.py
+++ b/src/devrev_mcp/tools/timeline.py
@@ -15,6 +15,7 @@ from devrev.models.timeline_entries import (
     TimelineEntriesListRequest,
     TimelineEntriesUpdateRequest,
     TimelineEntryType,
+    TimelineEntryVisibility,
 )
 from devrev_mcp.server import _config, mcp
 from devrev_mcp.utils.don_id import validate_don_id
@@ -84,6 +85,7 @@ if _config.enable_destructive_tools:
         object_id: str,
         type: str = "timeline_comment",
         body: str | None = None,
+        visibility: str | None = None,
     ) -> dict[str, Any]:
         """Create a new DevRev timeline entry.
 
@@ -92,6 +94,10 @@ if _config.enable_destructive_tools:
             type: Entry type (default: "timeline_comment"). Valid values: "timeline_comment",
                 "timeline_note", "timeline_event", "timeline_change_event".
             body: Entry content/body text.
+            visibility: Optional entry visibility. One of "external", "internal", "private",
+                or "public". If omitted, the DevRev server default ("external") is used. Use
+                "internal" to post to the ticket's internal-discussion tab; use "external" to
+                post a customer-facing comment.
         """
         app = ctx.request_context.lifespan_context
         try:
@@ -104,7 +110,22 @@ if _config.enable_destructive_tools:
                     f"timeline_comment, timeline_note, timeline_event, timeline_change_event"
                 ) from exc
 
-            request = TimelineEntriesCreateRequest(object=object_id, type=entry_type, body=body)
+            entry_visibility: TimelineEntryVisibility | None = None
+            if visibility is not None:
+                try:
+                    entry_visibility = TimelineEntryVisibility(visibility.lower())
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Invalid visibility: {visibility}. Valid values: "
+                        f"external, internal, private, public"
+                    ) from exc
+
+            request = TimelineEntriesCreateRequest(
+                object=object_id,
+                type=entry_type,
+                body=body,
+                visibility=entry_visibility,
+            )
             entry = await app.get_client().timeline_entries.create(request)
             return serialize_model(entry)
         except DevRevError as e:

--- a/tests/unit/mcp/test_tools_timeline.py
+++ b/tests/unit/mcp/test_tools_timeline.py
@@ -176,6 +176,86 @@ class TestTimelineCreateTool:
                 mock_ctx, object_id="don:core:ticket:123", type="invalid_type"
             )
 
+    async def test_timeline_create_with_internal_visibility(self, mock_ctx, mock_client):
+        """Internal visibility is forwarded on the create request."""
+        # Arrange
+        entry = _make_mock_timeline_entry({"body": "Internal note"})
+        mock_client.timeline_entries.create.return_value = entry
+
+        # Act
+        await devrev_timeline_create(
+            mock_ctx,
+            object_id="don:core:ticket:123",
+            type="timeline_comment",
+            body="Internal note",
+            visibility="internal",
+        )
+
+        # Assert
+        mock_client.timeline_entries.create.assert_called_once()
+        request = mock_client.timeline_entries.create.call_args.args[0]
+        assert request.visibility is not None
+        assert request.visibility.value == "internal"
+
+    async def test_timeline_create_with_external_visibility(self, mock_ctx, mock_client):
+        """External visibility is forwarded on the create request."""
+        # Arrange
+        entry = _make_mock_timeline_entry()
+        mock_client.timeline_entries.create.return_value = entry
+
+        # Act
+        await devrev_timeline_create(
+            mock_ctx,
+            object_id="don:core:ticket:123",
+            visibility="external",
+        )
+
+        # Assert
+        request = mock_client.timeline_entries.create.call_args.args[0]
+        assert request.visibility is not None
+        assert request.visibility.value == "external"
+
+    async def test_timeline_create_visibility_omitted_by_default(self, mock_ctx, mock_client):
+        """Visibility defaults to None (server default 'external' applies)."""
+        # Arrange
+        entry = _make_mock_timeline_entry()
+        mock_client.timeline_entries.create.return_value = entry
+
+        # Act
+        await devrev_timeline_create(mock_ctx, object_id="don:core:ticket:123")
+
+        # Assert
+        request = mock_client.timeline_entries.create.call_args.args[0]
+        assert request.visibility is None
+
+    async def test_timeline_create_visibility_case_insensitive(self, mock_ctx, mock_client):
+        """Visibility input is normalised to lower-case."""
+        # Arrange
+        entry = _make_mock_timeline_entry()
+        mock_client.timeline_entries.create.return_value = entry
+
+        # Act
+        await devrev_timeline_create(
+            mock_ctx,
+            object_id="don:core:ticket:123",
+            visibility="INTERNAL",
+        )
+
+        # Assert
+        request = mock_client.timeline_entries.create.call_args.args[0]
+        assert request.visibility is not None
+        assert request.visibility.value == "internal"
+
+    async def test_timeline_create_invalid_visibility(self, mock_ctx, mock_client):
+        """Invalid visibility values are rejected with ValueError."""
+        # Act & Assert
+        with pytest.raises(ValueError, match="Invalid visibility"):
+            await devrev_timeline_create(
+                mock_ctx,
+                object_id="don:core:ticket:123",
+                visibility="not-a-real-visibility",
+            )
+
 
 class TestTimelineUpdateTool:
     """Tests for devrev_timeline_update tool."""

--- a/tests/unit/services/test_timeline_entries.py
+++ b/tests/unit/services/test_timeline_entries.py
@@ -11,6 +11,7 @@ from devrev.models.timeline_entries import (
     TimelineEntriesUpdateRequest,
     TimelineEntry,
     TimelineEntryType,
+    TimelineEntryVisibility,
 )
 from devrev.services.timeline_entries import TimelineEntriesService
 
@@ -147,3 +148,78 @@ class TestTimelineEntriesService:
 
         assert len(result) == 0
         mock_http_client.post.assert_called_once()
+
+    def test_create_timeline_entry_with_internal_visibility(
+        self,
+        mock_http_client: MagicMock,
+        sample_timeline_entry_data: dict[str, Any],
+    ) -> None:
+        """Internal visibility is forwarded to the timeline-entries.create payload."""
+        mock_http_client.post.return_value = create_mock_response(
+            {"timeline_entry": sample_timeline_entry_data}
+        )
+
+        service = TimelineEntriesService(mock_http_client)
+        request = TimelineEntriesCreateRequest(
+            object="don:core:issue:456",
+            type=TimelineEntryType.COMMENT,
+            body="Internal note",
+            visibility=TimelineEntryVisibility.INTERNAL,
+        )
+        service.create(request)
+
+        mock_http_client.post.assert_called_once()
+        _, call_kwargs = mock_http_client.post.call_args
+        payload = call_kwargs["data"]
+        assert payload["visibility"] == "internal"
+        assert payload["body"] == "Internal note"
+
+    def test_create_timeline_entry_omits_visibility_when_unset(
+        self,
+        mock_http_client: MagicMock,
+        sample_timeline_entry_data: dict[str, Any],
+    ) -> None:
+        """When visibility is unset, it is excluded from the payload (server default)."""
+        mock_http_client.post.return_value = create_mock_response(
+            {"timeline_entry": sample_timeline_entry_data}
+        )
+
+        service = TimelineEntriesService(mock_http_client)
+        request = TimelineEntriesCreateRequest(
+            object="don:core:issue:456",
+            type=TimelineEntryType.COMMENT,
+            body="External comment",
+        )
+        service.create(request)
+
+        mock_http_client.post.assert_called_once()
+        _, call_kwargs = mock_http_client.post.call_args
+        payload = call_kwargs["data"]
+        assert "visibility" not in payload
+        assert "private_to" not in payload
+        assert "body_type" not in payload
+
+    def test_create_timeline_entry_with_private_visibility_and_recipients(
+        self,
+        mock_http_client: MagicMock,
+        sample_timeline_entry_data: dict[str, Any],
+    ) -> None:
+        """Private visibility with private_to is forwarded as-is."""
+        mock_http_client.post.return_value = create_mock_response(
+            {"timeline_entry": sample_timeline_entry_data}
+        )
+
+        service = TimelineEntriesService(mock_http_client)
+        request = TimelineEntriesCreateRequest(
+            object="don:core:issue:456",
+            type=TimelineEntryType.COMMENT,
+            body="Private",
+            visibility=TimelineEntryVisibility.PRIVATE,
+            private_to=["don:identity:dvrv-us-1:devo/1:devu/2"],
+        )
+        service.create(request)
+
+        _, call_kwargs = mock_http_client.post.call_args
+        payload = call_kwargs["data"]
+        assert payload["visibility"] == "private"
+        assert payload["private_to"] == ["don:identity:dvrv-us-1:devo/1:devu/2"]


### PR DESCRIPTION
## Summary

Adds an optional `visibility` parameter (`external` / `internal` / `private` / `public`) to the `devrev_timeline_create` MCP tool, plumbed through `TimelineEntriesCreateRequest` to the DevRev REST `timeline-entries.create` endpoint. This lets MCP callers post to a ticket's **internal-discussion tab**, which previously required manual paste in the DevRev UI.

Linear: [CUSS-569](https://linear.app/augmentcode/issue/CUSS-569) — *py-dev-rev MCP: devrev_timeline_create cannot post internal-visibility comments*

## Motivation

The DevRev REST `timeline-entries.create` API already accepts a `visibility` field (enum `timeline-entry-visibility`, default `external`), but the MCP wrapper only forwarded `object_id`, `type`, and `body`. As a result:

- `devrev_timeline_create(type="timeline_note", ...)` returns `Validation error: Bad Request` for support-ticket objects, so internal investigation summaries can't be posted via MCP.
- Mirrors the visibility semantics already used by other DevRev clients (e.g. `add_comment`).

Hit during real Augment support investigations on TKT-64435 and TKT-64487; both required clipboard-and-paste workarounds.

## Changes

- `devrev/models/timeline_entries.py`
  - New `TimelineEntryVisibility` enum (`external`, `internal`, `private`, `public`).
  - `TimelineEntriesCreateRequest` gains optional `visibility`, `private_to`, and `body_type` fields. All default to `None` and are excluded from the wire payload when unset (`exclude_none=True` in `BaseService._post`), so existing callers and the server default (`external`) are unchanged.
- `devrev/models/__init__.py` — re-export `TimelineEntryVisibility`.
- `devrev_mcp/tools/timeline.py` — `devrev_timeline_create` accepts an optional `visibility: str` argument. Case-insensitive parsing, with a clear `ValueError` (`"Invalid visibility: ..."`) for unknown values. Forwarded onto `TimelineEntriesCreateRequest`.
- `docs/changelog.md` — Unreleased entry.
- Tests:
  - `tests/unit/services/test_timeline_entries.py` — internal visibility forwarded; default-omitted path; private + `private_to` round-trip.
  - `tests/unit/mcp/test_tools_timeline.py` — internal/external/no-visibility/case-insensitivity/invalid-value cases on the MCP tool.

No behavioural change for existing callers (visibility defaults to `None` ⇒ field omitted from request body).

## Example

```python
await devrev_timeline_create(
    object_id="don:core:dvrv-us-1:devo/1:ticket/64487",
    type="timeline_comment",
    body="Investigation summary for ASA agent (internal).",
    visibility="internal",  # NEW — posts to internal-discussion tab
)
```

## Verification

Local (Python 3.13, project `uv` env):

```
uv run ruff format .            # clean
uv run ruff check .             # All checks passed
uv run mypy src/devrev src/devrev_mcp   # Success
uv run pytest tests/unit         # all green (full unit suite)
uv run --extra docs mkdocs build --strict   # Documentation built
```

No new dependencies. No public-API breakage — all new fields/parameters are optional with `None` defaults.

## Checklist

- [x] Tests added (service + MCP layers, happy-path + error path)
- [x] Existing tests still pass (`uv run pytest tests/unit`)
- [x] `ruff format` / `ruff check` / `mypy` clean
- [x] Changelog updated
- [ ] Maintainer review

Marked draft pending maintainer review and any feedback on naming/shape (happy to align with the project's preferred conventions for visibility).


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author