### PR TITLE
Enhance ticket SDK coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ The SDK provides complete coverage of all 209 DevRev public API endpoints, organ
 |---------|-----------|-------------|
 | **Articles** | 5 | Knowledge base articles |
 | **Conversations** | 5 | Customer conversations |
+| **Survey Responses** | 1 | Survey and CSAT response listing |
 | **Timeline Entries** | 5 | Activity timeline management |
 | **Tags** | 5 | Tagging and categorization |
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ for account in accounts:
 work = client.works.get(id="don:core:...")
 print(f"Work: {work.title} - Status: {work.stage.name}")
 
+# Ticket integrations can read optional account/sentiment/SLA fields
+ticket = client.works.get(id="don:core:dvrv-us-1:devo/1:ticket/123")
+print(ticket.rev_org, ticket.account, ticket.needs_response)
+
+# Use a supported raw escape hatch when the API returns newer fields
+raw_ticket = client.works.get_raw(id="don:core:dvrv-us-1:devo/1:ticket/123")
+print(raw_ticket["work"].keys())
+
+# List survey/CSAT responses for a ticket without using private _http
+survey_responses = client.survey_responses.list(object_id=ticket.id)
+
 # Create a new ticket
 ticket = client.works.create(
     title="Bug: Login page not loading",

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -44,6 +44,7 @@ All API operations are organized into service classes:
 | [Parts](services/parts.md) | Product components | 5 |
 | [Articles](services/articles.md) | Knowledge base | 5 |
 | [Conversations](services/conversations.md) | Customer conversations | 5 |
+| [Survey Responses](services/survey-responses.md) | Survey and CSAT responses | 1 |
 | [Tags](services/tags.md) | Categorization | 5 |
 | [Groups](services/groups.md) | User groups | 6 |
 | [Webhooks](services/webhooks.md) | Event notifications | 6 |
@@ -77,6 +78,7 @@ Request and response models:
 |--------|-------------|
 | [Base](models/base.md) | Common base classes |
 | [Accounts](models/accounts.md) | Account models |
+| [Survey Responses](models/survey-responses.md) | Survey response models |
 | [Works](models/works.md) | Work item models |
 | [Users](models/users.md) | User models |
 

--- a/docs/api/models/index.md
+++ b/docs/api/models/index.md
@@ -30,6 +30,7 @@ Models for specific resources:
 | Resource | Description |
 |----------|-------------|
 | [Accounts](accounts.md) | Customer account models |
+| [Survey Responses](survey-responses.md) | Survey response list and payload models |
 | [Works](works.md) | Work item models (tickets, issues) |
 | [Users](users.md) | User models (dev and rev users) |
 

--- a/docs/api/models/survey-responses.md
+++ b/docs/api/models/survey-responses.md
@@ -1,0 +1,47 @@
+# Survey Response Models
+
+Models for survey and CSAT response operations.
+
+## SurveyResponse
+
+The main survey response model.
+
+::: devrev.models.survey_responses.SurveyResponse
+    options:
+      show_source: true
+
+## Enums
+
+### SurveyResponsesListMode
+
+::: devrev.models.survey_responses.SurveyResponsesListMode
+    options:
+      show_source: true
+
+## Request Models
+
+### SurveyResponsesListRequest
+
+::: devrev.models.survey_responses.SurveyResponsesListRequest
+    options:
+      show_source: true
+
+## Response Models
+
+### SurveyResponsesListResponse
+
+::: devrev.models.survey_responses.SurveyResponsesListResponse
+    options:
+      show_source: true
+
+## Usage Examples
+
+### Work with survey responses
+
+```python
+responses = client.survey_responses.list(object_id="don:core:...", limit=10)
+
+for survey_response in responses.survey_responses:
+    print(survey_response.id)
+    print(survey_response.response)
+```

--- a/docs/api/models/works.md
+++ b/docs/api/models/works.md
@@ -111,6 +111,9 @@ print(f"Stage: {work.stage.name if work.stage else 'N/A'}")
 
 if work.type == WorkType.TICKET:
     print(f"Severity: {work.severity}")
+    print(f"Account: {work.account}")
+    print(f"Rev org: {work.rev_org}")
+    print(f"Needs response: {work.needs_response}")
 elif work.type == WorkType.ISSUE:
     print(f"Priority: {work.priority}")
 ```

--- a/docs/api/services/index.md
+++ b/docs/api/services/index.md
@@ -36,6 +36,7 @@ client.dev_users     # DevUsersService
 |---------|-------------|-----------|
 | **Articles** | Knowledge base articles with unified content management | [articles](articles.md) |
 | **Conversations** | Customer conversations | [conversations](conversations.md) |
+| **Survey Responses** | Survey and CSAT responses | [survey-responses](survey-responses.md) |
 | **Tags** | Categorization | [tags](tags.md) |
 | **Timeline Entries** | Activity tracking | [timeline-entries](timeline-entries.md) |
 

--- a/docs/api/services/survey-responses.md
+++ b/docs/api/services/survey-responses.md
@@ -1,0 +1,77 @@
+# Survey Responses Service
+
+List survey and CSAT responses in DevRev.
+
+Use this service when a ticket or work sync needs survey responses without
+reaching through the private client transport.
+
+## SurveyResponsesService
+
+::: devrev.services.survey_responses.SurveyResponsesService
+    options:
+      show_source: true
+      members:
+        - list
+
+## AsyncSurveyResponsesService
+
+::: devrev.services.survey_responses.AsyncSurveyResponsesService
+    options:
+      show_source: true
+      members:
+        - list
+
+## Usage Examples
+
+### List responses for a ticket/work object
+
+```python
+from devrev import DevRevClient
+
+client = DevRevClient()
+
+responses = client.survey_responses.list(
+    object_id="don:core:dvrv-us-1:devo/1:ticket/123",
+    limit=50,
+)
+
+for survey_response in responses.survey_responses:
+    print(survey_response.id, survey_response.response)
+```
+
+### Filter with multiple objects
+
+```python
+responses = client.survey_responses.list(
+    objects=[
+        "don:core:dvrv-us-1:devo/1:ticket/123",
+        "don:core:dvrv-us-1:devo/1:ticket/456",
+    ],
+)
+```
+
+### Async usage
+
+```python
+import asyncio
+
+from devrev import AsyncDevRevClient
+
+
+async def main():
+    async with AsyncDevRevClient() as client:
+        responses = await client.survey_responses.list(
+            object_id="don:core:dvrv-us-1:devo/1:ticket/123",
+        )
+        print(len(responses.survey_responses))
+
+
+asyncio.run(main())
+```
+
+## Related Models
+
+- `SurveyResponse`
+- `SurveyResponsesListRequest`
+- `SurveyResponsesListResponse`
+- `SurveyResponsesListMode`

--- a/docs/api/services/survey-responses.md
+++ b/docs/api/services/survey-responses.md
@@ -69,9 +69,15 @@ async def main():
 asyncio.run(main())
 ```
 
+## Pagination
+
+`survey_responses.list(...)` returns a paginated response with `next_cursor`.
+When you need more than one page, pass the returned cursor into a follow-up
+call and continue until `next_cursor` is `None`.
+
 ## Related Models
 
-- `SurveyResponse`
-- `SurveyResponsesListRequest`
-- `SurveyResponsesListResponse`
-- `SurveyResponsesListMode`
+- [`SurveyResponse`](../models/survey-responses.md#surveyresponse)
+- [`SurveyResponsesListRequest`](../models/survey-responses.md#surveyresponseslistrequest)
+- [`SurveyResponsesListResponse`](../models/survey-responses.md#surveyresponseslistresponse)
+- [`SurveyResponsesListMode`](../models/survey-responses.md#surveyresponseslistmode)

--- a/docs/api/services/works.md
+++ b/docs/api/services/works.md
@@ -13,6 +13,7 @@ issues (engineering), and tasks.
       members:
         - list
         - get
+        - get_raw
         - create
         - update
         - delete
@@ -57,11 +58,37 @@ response = client.works.list(
 ### Get Work Item
 
 ```python
-response = client.works.get(id="don:core:dvrv-us-1:devo/1:ticket/123")
-work = response.work
+work = client.works.get(id="don:core:dvrv-us-1:devo/1:ticket/123")
 print(f"Title: {work.title}")
 print(f"Type: {work.type}")
 print(f"Stage: {work.stage.name if work.stage else 'N/A'}")
+```
+
+### Get Raw Work Payload
+
+Use `get_raw` when the REST API returns a newly-added field that is not yet
+modeled by the typed `Work` object. This keeps callers on a supported SDK API
+instead of relying on the private `_http` transport.
+
+```python
+payload = client.works.get_raw(id="don:core:dvrv-us-1:devo/1:ticket/123")
+raw_work = payload["work"]
+print(raw_work.get("rev_org"))
+```
+
+### Ticket Account Association
+
+For tickets, the typed `Work` model now includes optional account-association
+fields when the API returns them. Prefer the typed fields first, and use
+`get_raw` only as a fallback for workspace-specific or newly-added fields.
+
+```python
+ticket = client.works.get(id="don:core:dvrv-us-1:devo/1:ticket/123")
+
+if ticket.rev_org:
+    print(f"Ticket rev org: {ticket.rev_org}")
+if ticket.account:
+    print(f"Ticket account: {ticket.account}")
 ```
 
 ### Create Ticket

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [3.0.4] - 2026-05-03
+
+### Added
+
 - **Ticket SDK coverage enhancements** (CUSS-370, GitHub #220) — Added optional
   typed `Work` fields used by ticket integrations (`account`, `rev_org`,
   sentiment fields, `sla_summary`, `needs_response`, channels, group,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Ticket SDK coverage enhancements** (CUSS-370, GitHub #220) — Added optional
+  typed `Work` fields used by ticket integrations (`account`, `rev_org`,
+  sentiment fields, `sla_summary`, `needs_response`, channels, group,
+  `is_frozen`, and `visibility`), a public `WorksService.get_raw` /
+  `AsyncWorksService.get_raw` escape hatch for raw `/works.get` payloads, and
+  new sync/async `survey_responses.list(...)` support for
+  `/surveys.responses.list`.
+
 ### Changed
 
 ### Fixed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -181,6 +181,7 @@ nav:
       - api/models/index.md
       - Base: api/models/base.md
       - Accounts: api/models/accounts.md
+      - Survey Responses: api/models/survey-responses.md
       - Works: api/models/works.md
       - Users: api/models/users.md
   - Examples:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -169,6 +169,7 @@ nav:
       - Parts: api/services/parts.md
       - Articles: api/services/articles.md
       - Conversations: api/services/conversations.md
+      - Survey Responses: api/services/survey-responses.md
       - Tags: api/services/tags.md
       - Groups: api/services/groups.md
       - Webhooks: api/services/webhooks.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "devrev-Python-SDK"
-version = "3.0.3"
+version = "3.0.4"
 description = "A modern, type-safe Python SDK for the DevRev API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/devrev/client.py
+++ b/src/devrev/client.py
@@ -42,6 +42,10 @@ from devrev.services.rev_orgs import AsyncRevOrgsService, RevOrgsService
 from devrev.services.rev_users import AsyncRevUsersService, RevUsersService
 from devrev.services.search import AsyncSearchService, SearchService
 from devrev.services.slas import AsyncSlasService, SlasService
+from devrev.services.survey_responses import (
+    AsyncSurveyResponsesService,
+    SurveyResponsesService,
+)
 from devrev.services.tags import AsyncTagsService, TagsService
 from devrev.services.timeline_entries import (
     AsyncTimelineEntriesService,
@@ -164,6 +168,7 @@ class DevRevClient:
         self._rev_orgs = RevOrgsService(self._http)
         self._rev_users = RevUsersService(self._http)
         self._slas = SlasService(self._http)
+        self._survey_responses = SurveyResponsesService(self._http)
         self._tags = TagsService(self._http)
         self._timeline_entries = TimelineEntriesService(self._http)
         self._webhooks = WebhooksService(self._http)
@@ -258,6 +263,11 @@ class DevRevClient:
     def slas(self) -> SlasService:
         """Access the SLAs service."""
         return self._slas
+
+    @property
+    def survey_responses(self) -> SurveyResponsesService:
+        """Access the Survey Responses service."""
+        return self._survey_responses
 
     @property
     def tags(self) -> TagsService:
@@ -492,6 +502,7 @@ class AsyncDevRevClient:
         self._rev_orgs = AsyncRevOrgsService(self._http)
         self._rev_users = AsyncRevUsersService(self._http)
         self._slas = AsyncSlasService(self._http)
+        self._survey_responses = AsyncSurveyResponsesService(self._http)
         self._tags = AsyncTagsService(self._http)
         self._timeline_entries = AsyncTimelineEntriesService(self._http)
         self._webhooks = AsyncWebhooksService(self._http)
@@ -586,6 +597,11 @@ class AsyncDevRevClient:
     def slas(self) -> AsyncSlasService:
         """Access the SLAs service."""
         return self._slas
+
+    @property
+    def survey_responses(self) -> AsyncSurveyResponsesService:
+        """Access the Survey Responses service."""
+        return self._survey_responses
 
     @property
     def tags(self) -> AsyncTagsService:

--- a/src/devrev/models/__init__.py
+++ b/src/devrev/models/__init__.py
@@ -328,6 +328,12 @@ from devrev.models.slas import (
     SlasUpdateResponse,
     SlaTrackerStatus,
 )
+from devrev.models.survey_responses import (
+    SurveyResponse,
+    SurveyResponsesListMode,
+    SurveyResponsesListRequest,
+    SurveyResponsesListResponse,
+)
 from devrev.models.sync import (
     ExternalRef,
     StagedInfo,
@@ -699,6 +705,11 @@ __all__ = [
     "QuestionAnswersUpdateRequest",
     "QuestionAnswersUpdateResponse",
     "QuestionAnswersDeleteRequest",
+    # Survey Responses
+    "SurveyResponse",
+    "SurveyResponsesListMode",
+    "SurveyResponsesListRequest",
+    "SurveyResponsesListResponse",
     # Recommendations
     "MessageRole",
     "ChatMessage",

--- a/src/devrev/models/survey_responses.py
+++ b/src/devrev/models/survey_responses.py
@@ -1,0 +1,77 @@
+"""Survey response models for DevRev SDK.
+
+This module contains Pydantic models for the ``surveys.responses.list`` API.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import ConfigDict, Field
+
+from devrev.models.base import DevRevBaseModel, DevRevResponseModel, PaginatedResponse
+
+
+class SurveyResponsesListMode(StrEnum):
+    """Survey response cursor iteration mode."""
+
+    AFTER = "after"
+    BEFORE = "before"
+
+
+class SurveyResponse(DevRevResponseModel):
+    """DevRev survey response model."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True, str_strip_whitespace=True)
+
+    id: str = Field(..., description="Survey response ID")
+    display_id: str | None = Field(default=None, description="Human-readable display ID")
+    created_by: dict[str, Any] | None = Field(default=None, description="Creator user summary")
+    created_date: datetime | None = Field(default=None, description="Creation timestamp")
+    modified_by: dict[str, Any] | None = Field(default=None, description="Modifier user summary")
+    modified_date: datetime | None = Field(default=None, description="Last modification timestamp")
+    object_version: int | None = Field(default=None, description="Object version")
+    dispatch_id: str | None = Field(default=None, description="Dispatched survey ID")
+    dispatched_channels: list[dict[str, Any]] | None = Field(
+        default=None,
+        description="Channels on which the survey was dispatched",
+    )
+    object: str | None = Field(default=None, description="Object for which the survey was taken")
+    recipient: dict[str, Any] | str | None = Field(default=None, description="Survey recipient")
+    response: dict[str, Any] | str | int | float | bool | None = Field(
+        default=None,
+        description="Survey response payload",
+    )
+    stage: dict[str, Any] | int | str | None = Field(default=None, description="Survey stage")
+    survey: dict[str, Any] | str | None = Field(default=None, description="Survey summary or ID")
+
+
+class SurveyResponsesListRequest(DevRevBaseModel):
+    """Request to list survey responses."""
+
+    created_by: list[str] | None = Field(default=None, description="Creator user filters")
+    cursor: str | None = Field(default=None, description="Pagination cursor")
+    dispatch_ids: list[str] | None = Field(default=None, description="Survey dispatch IDs")
+    limit: int | None = Field(default=None, ge=1, le=100, description="Maximum results")
+    mode: SurveyResponsesListMode | None = Field(default=None, description="Cursor iteration mode")
+    object_id: str | None = Field(
+        default=None,
+        alias="object",
+        description="Single object ID to filter responses by",
+    )
+    objects: list[str] | None = Field(default=None, description="Object IDs to filter responses by")
+    recipient: list[str] | None = Field(default=None, description="Recipient user filters")
+    sort_by: list[str] | None = Field(default=None, description="Sort order entries")
+    stages: list[int] | None = Field(default=None, description="Survey response stage filters")
+    surveys: list[str] | None = Field(default=None, description="Survey IDs to filter by")
+
+
+class SurveyResponsesListResponse(PaginatedResponse):
+    """Response from listing survey responses."""
+
+    survey_responses: list[SurveyResponse] = Field(
+        default_factory=list,
+        description="List of survey responses",
+    )

--- a/src/devrev/models/works.py
+++ b/src/devrev/models/works.py
@@ -104,7 +104,10 @@ class Work(DevRevResponseModel):
         default=None,
         description="Rev organization associated with the ticket/work",
     )
-    sentiment: str | None = Field(default=None, description="Current ticket sentiment")
+    sentiment: dict[str, Any] | str | None = Field(
+        default=None,
+        description="Current ticket sentiment, when returned by the API",
+    )
     sentiment_summary: dict[str, Any] | str | None = Field(
         default=None,
         description="Structured or textual sentiment summary",
@@ -131,7 +134,10 @@ class Work(DevRevResponseModel):
         description="Group associated with the work item",
     )
     is_frozen: bool | None = Field(default=None, description="Whether the work item is frozen")
-    visibility: str | None = Field(default=None, description="Work item visibility")
+    visibility: dict[str, Any] | str | None = Field(
+        default=None,
+        description="Work item visibility, when returned by the API",
+    )
 
 
 class WorkSummary(DevRevResponseModel):

--- a/src/devrev/models/works.py
+++ b/src/devrev/models/works.py
@@ -96,6 +96,42 @@ class Work(DevRevResponseModel):
     actual_close_date: datetime | None = Field(default=None, description="Actual close date")
     custom_fields: dict[str, Any] | None = Field(default=None, description="Custom fields")
     external_ref: str | None = Field(default=None, description="External reference")
+    account: dict[str, Any] | str | None = Field(
+        default=None,
+        description="Account associated with the ticket/work, when returned by the API",
+    )
+    rev_org: dict[str, Any] | str | None = Field(
+        default=None,
+        description="Rev organization associated with the ticket/work",
+    )
+    sentiment: str | None = Field(default=None, description="Current ticket sentiment")
+    sentiment_summary: dict[str, Any] | str | None = Field(
+        default=None,
+        description="Structured or textual sentiment summary",
+    )
+    sentiment_modified_date: datetime | None = Field(
+        default=None,
+        description="When ticket sentiment was last modified",
+    )
+    sla_summary: dict[str, Any] | None = Field(default=None, description="Ticket SLA summary")
+    needs_response: bool | None = Field(
+        default=None,
+        description="Whether the ticket needs a customer response",
+    )
+    channels: list[dict[str, Any] | str] | None = Field(
+        default=None,
+        description="Channels associated with the ticket",
+    )
+    source_channel: dict[str, Any] | str | None = Field(
+        default=None,
+        description="Source channel that created the ticket",
+    )
+    group: dict[str, Any] | str | None = Field(
+        default=None,
+        description="Group associated with the work item",
+    )
+    is_frozen: bool | None = Field(default=None, description="Whether the work item is frozen")
+    visibility: str | None = Field(default=None, description="Work item visibility")
 
 
 class WorkSummary(DevRevResponseModel):

--- a/src/devrev/services/__init__.py
+++ b/src/devrev/services/__init__.py
@@ -38,6 +38,7 @@ from devrev.services.rev_orgs import AsyncRevOrgsService, RevOrgsService
 from devrev.services.rev_users import AsyncRevUsersService, RevUsersService
 from devrev.services.search import AsyncSearchService, SearchService
 from devrev.services.slas import AsyncSlasService, SlasService
+from devrev.services.survey_responses import AsyncSurveyResponsesService, SurveyResponsesService
 from devrev.services.tags import AsyncTagsService, TagsService
 from devrev.services.timeline_entries import (
     AsyncTimelineEntriesService,
@@ -112,6 +113,9 @@ __all__ = [
     # SLAs
     "SlasService",
     "AsyncSlasService",
+    # Survey Responses
+    "SurveyResponsesService",
+    "AsyncSurveyResponsesService",
     # Tags
     "TagsService",
     "AsyncTagsService",

--- a/src/devrev/services/survey_responses.py
+++ b/src/devrev/services/survey_responses.py
@@ -89,7 +89,24 @@ class AsyncSurveyResponsesService(AsyncBaseService):
         stages: Sequence[int] | None = None,
         surveys: Sequence[str] | None = None,
     ) -> SurveyResponsesListResponse:
-        """List survey responses."""
+        """List survey responses.
+
+        Args:
+            object_id: Convenience filter for a single ticket/work/object ID.
+            objects: Object IDs to filter responses by.
+            created_by: Creator user filters.
+            cursor: Pagination cursor.
+            dispatch_ids: Survey dispatch IDs.
+            limit: Maximum number of responses to return.
+            mode: Cursor iteration mode.
+            recipient: Recipient user filters.
+            sort_by: Sort order entries.
+            stages: Survey response stage filters.
+            surveys: Survey IDs to filter by.
+
+        Returns:
+            Paginated survey response list.
+        """
         request = SurveyResponsesListRequest(
             created_by=list(created_by) if created_by else None,
             cursor=cursor,

--- a/src/devrev/services/survey_responses.py
+++ b/src/devrev/services/survey_responses.py
@@ -1,0 +1,105 @@
+"""Survey response service for DevRev SDK."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from devrev.models.survey_responses import (
+    SurveyResponsesListMode,
+    SurveyResponsesListRequest,
+    SurveyResponsesListResponse,
+)
+from devrev.services.base import AsyncBaseService, BaseService
+
+
+def _merge_object_filters(object_id: str | None, objects: Sequence[str] | None) -> list[str] | None:
+    """Merge singular and plural object filters without duplicates."""
+    merged = list(objects or [])
+    if object_id and object_id not in merged:
+        merged.insert(0, object_id)
+    return merged or None
+
+
+class SurveyResponsesService(BaseService):
+    """Synchronous service for survey/CSAT responses."""
+
+    def list(
+        self,
+        *,
+        object_id: str | None = None,
+        objects: Sequence[str] | None = None,
+        created_by: Sequence[str] | None = None,
+        cursor: str | None = None,
+        dispatch_ids: Sequence[str] | None = None,
+        limit: int | None = None,
+        mode: SurveyResponsesListMode | None = None,
+        recipient: Sequence[str] | None = None,
+        sort_by: Sequence[str] | None = None,
+        stages: Sequence[int] | None = None,
+        surveys: Sequence[str] | None = None,
+    ) -> SurveyResponsesListResponse:
+        """List survey responses.
+
+        Args:
+            object_id: Convenience filter for a single ticket/work/object ID.
+            objects: Object IDs to filter responses by.
+            created_by: Creator user filters.
+            cursor: Pagination cursor.
+            dispatch_ids: Survey dispatch IDs.
+            limit: Maximum number of responses to return.
+            mode: Cursor iteration mode.
+            recipient: Recipient user filters.
+            sort_by: Sort order entries.
+            stages: Survey response stage filters.
+            surveys: Survey IDs to filter by.
+
+        Returns:
+            Paginated survey response list.
+        """
+        request = SurveyResponsesListRequest(
+            created_by=list(created_by) if created_by else None,
+            cursor=cursor,
+            dispatch_ids=list(dispatch_ids) if dispatch_ids else None,
+            limit=limit,
+            mode=mode,
+            objects=_merge_object_filters(object_id, objects),
+            recipient=list(recipient) if recipient else None,
+            sort_by=list(sort_by) if sort_by else None,
+            stages=list(stages) if stages else None,
+            surveys=list(surveys) if surveys else None,
+        )
+        return self._post("/surveys.responses.list", request, SurveyResponsesListResponse)
+
+
+class AsyncSurveyResponsesService(AsyncBaseService):
+    """Asynchronous service for survey/CSAT responses."""
+
+    async def list(
+        self,
+        *,
+        object_id: str | None = None,
+        objects: Sequence[str] | None = None,
+        created_by: Sequence[str] | None = None,
+        cursor: str | None = None,
+        dispatch_ids: Sequence[str] | None = None,
+        limit: int | None = None,
+        mode: SurveyResponsesListMode | None = None,
+        recipient: Sequence[str] | None = None,
+        sort_by: Sequence[str] | None = None,
+        stages: Sequence[int] | None = None,
+        surveys: Sequence[str] | None = None,
+    ) -> SurveyResponsesListResponse:
+        """List survey responses."""
+        request = SurveyResponsesListRequest(
+            created_by=list(created_by) if created_by else None,
+            cursor=cursor,
+            dispatch_ids=list(dispatch_ids) if dispatch_ids else None,
+            limit=limit,
+            mode=mode,
+            objects=_merge_object_filters(object_id, objects),
+            recipient=list(recipient) if recipient else None,
+            sort_by=list(sort_by) if sort_by else None,
+            stages=list(stages) if stages else None,
+            surveys=list(surveys) if surveys else None,
+        )
+        return await self._post("/surveys.responses.list", request, SurveyResponsesListResponse)

--- a/src/devrev/services/works.py
+++ b/src/devrev/services/works.py
@@ -147,6 +147,21 @@ class WorksService(BaseService):
         response = self._post("/works.get", request, WorksGetResponse)
         return response.work
 
+    def get_raw(self, id: str) -> dict[str, Any]:
+        """Get the raw API payload for a work item.
+
+        Use this supported escape hatch when the DevRev API returns fields that
+        are not yet represented on the typed :class:`Work` model.
+
+        Args:
+            id: Work item ID
+
+        Returns:
+            Raw ``/works.get`` response payload.
+        """
+        request = WorksGetRequest(id=id)
+        return self._post("/works.get", request)
+
     def list(
         self,
         *,
@@ -438,6 +453,11 @@ class AsyncWorksService(AsyncBaseService):
         request = WorksGetRequest(id=id)
         response = await self._post("/works.get", request, WorksGetResponse)
         return response.work
+
+    async def get_raw(self, id: str) -> dict[str, Any]:
+        """Get the raw API payload for a work item."""
+        request = WorksGetRequest(id=id)
+        return await self._post("/works.get", request)
 
     async def list(
         self,

--- a/tests/unit/services/test_survey_responses.py
+++ b/tests/unit/services/test_survey_responses.py
@@ -83,6 +83,29 @@ class TestSurveyResponsesService:
         assert kwargs["data"]["objects"] == ["don:core:ticket:456", "don:core:ticket:789"]
         assert kwargs["data"]["mode"] == "after"
 
+    def test_list_prepends_new_object_id_to_objects(self) -> None:
+        """object_id NOT already in objects is inserted at position 0.
+
+        This exercises the ``insert(0, object_id)`` branch of
+        ``_merge_object_filters`` — the complementary case to the deduplication
+        test above, where object_id IS already present.
+        """
+        mock_http_client = MagicMock()
+        mock_http_client.post.return_value = create_mock_response({"survey_responses": []})
+
+        service = SurveyResponsesService(mock_http_client)
+        service.list(
+            object_id="don:core:ticket:NEW",
+            objects=["don:core:ticket:456", "don:core:ticket:789"],
+        )
+
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs["data"]["objects"] == [
+            "don:core:ticket:NEW",
+            "don:core:ticket:456",
+            "don:core:ticket:789",
+        ]
+
 
 class TestAsyncSurveyResponsesService:
     """Tests for AsyncSurveyResponsesService."""

--- a/tests/unit/services/test_survey_responses.py
+++ b/tests/unit/services/test_survey_responses.py
@@ -1,0 +1,106 @@
+"""Unit tests for SurveyResponsesService."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from devrev.models.survey_responses import (
+    SurveyResponse,
+    SurveyResponsesListMode,
+    SurveyResponsesListResponse,
+)
+from devrev.services.survey_responses import AsyncSurveyResponsesService, SurveyResponsesService
+
+
+def create_mock_response(data: dict[str, Any], status_code: int = 200) -> MagicMock:
+    """Create a mock HTTP response."""
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.is_success = 200 <= status_code < 300
+    response.json.return_value = data
+    return response
+
+
+@pytest.fixture
+def sample_survey_response_data() -> dict[str, Any]:
+    """Sample survey response payload."""
+    return {
+        "id": "don:core:survey_response:123",
+        "display_id": "SURVR-123",
+        "created_date": "2024-01-15T10:00:00Z",
+        "object": "don:core:ticket:456",
+        "dispatch_id": "dispatch-123",
+        "response": {"score": 5, "comment": "Great support"},
+        "survey": "don:core:survey:789",
+        "unexpected_api_field": "preserved",
+    }
+
+
+class TestSurveyResponsesService:
+    """Tests for SurveyResponsesService."""
+
+    def test_list_survey_responses_by_object(
+        self,
+        sample_survey_response_data: dict[str, Any],
+    ) -> None:
+        mock_http_client = MagicMock()
+        mock_http_client.post.return_value = create_mock_response(
+            {"survey_responses": [sample_survey_response_data], "next_cursor": "next"}
+        )
+
+        service = SurveyResponsesService(mock_http_client)
+        result = service.list(object_id="don:core:ticket:456", limit=10)
+
+        assert isinstance(result, SurveyResponsesListResponse)
+        assert result.next_cursor == "next"
+        assert len(result.survey_responses) == 1
+        response = result.survey_responses[0]
+        assert isinstance(response, SurveyResponse)
+        assert response.object == "don:core:ticket:456"
+        assert response.response == {"score": 5, "comment": "Great support"}
+        assert response.model_extra is not None
+        assert response.model_extra["unexpected_api_field"] == "preserved"
+        mock_http_client.post.assert_called_once()
+        (endpoint,) = mock_http_client.post.call_args.args
+        _, kwargs = mock_http_client.post.call_args
+        assert endpoint == "/surveys.responses.list"
+        assert kwargs["data"] == {"limit": 10, "objects": ["don:core:ticket:456"]}
+
+    def test_list_merges_object_filters_without_duplicates(self) -> None:
+        mock_http_client = MagicMock()
+        mock_http_client.post.return_value = create_mock_response({"survey_responses": []})
+
+        service = SurveyResponsesService(mock_http_client)
+        service.list(
+            object_id="don:core:ticket:456",
+            objects=["don:core:ticket:456", "don:core:ticket:789"],
+            mode=SurveyResponsesListMode.AFTER,
+        )
+
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs["data"]["objects"] == ["don:core:ticket:456", "don:core:ticket:789"]
+        assert kwargs["data"]["mode"] == "after"
+
+
+class TestAsyncSurveyResponsesService:
+    """Tests for AsyncSurveyResponsesService."""
+
+    @pytest.mark.asyncio
+    async def test_async_list_survey_responses(
+        self,
+        sample_survey_response_data: dict[str, Any],
+    ) -> None:
+        mock_async_client = AsyncMock()
+        mock_async_client.post.return_value = create_mock_response(
+            {"survey_responses": [sample_survey_response_data]}
+        )
+
+        service = AsyncSurveyResponsesService(mock_async_client)
+        result = await service.list(object_id="don:core:ticket:456")
+
+        assert len(result.survey_responses) == 1
+        assert result.survey_responses[0].id == "don:core:survey_response:123"
+        _, kwargs = mock_async_client.post.call_args
+        assert kwargs["data"] == {"objects": ["don:core:ticket:456"]}

--- a/tests/unit/services/test_works.py
+++ b/tests/unit/services/test_works.py
@@ -86,6 +86,65 @@ class TestWorksService:
         assert isinstance(result, Work)
         assert result.id == "don:core:issue:123"
 
+    def test_get_raw_work_returns_unparsed_payload(
+        self,
+        mock_http_client: MagicMock,
+        sample_work_data: dict[str, Any],
+    ) -> None:
+        """Test supported raw-response escape hatch for works.get."""
+        raw_payload = {"work": sample_work_data, "server_extra": {"unknown": True}}
+        mock_http_client.post.return_value = create_mock_response(raw_payload)
+
+        service = WorksService(mock_http_client)
+        result = service.get_raw("don:core:issue:123")
+
+        assert result == raw_payload
+        mock_http_client.post.assert_called_once()
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs["data"] == {"id": "don:core:issue:123"}
+
+    def test_work_parses_ticket_integration_fields(
+        self,
+        mock_http_client: MagicMock,
+        sample_work_data: dict[str, Any],
+    ) -> None:
+        """Test optional ticket fields needed by downstream integrations."""
+        sample_work_data.update(
+            {
+                "type": "ticket",
+                "account": {"id": "don:core:account:123", "display_name": "Acme"},
+                "rev_org": {"id": "don:core:rev_org:123", "display_name": "Acme"},
+                "sentiment": "positive",
+                "sentiment_summary": {"summary": "Customer is happy"},
+                "sentiment_modified_date": "2024-01-16T10:00:00Z",
+                "sla_summary": {"stage": "active", "remaining_time": 3600},
+                "needs_response": True,
+                "channels": [{"id": 3, "label": "email"}, "plug"],
+                "source_channel": {"id": 3, "label": "email"},
+                "group": {"id": "don:core:group:123", "name": "Support"},
+                "is_frozen": False,
+                "visibility": "external",
+            }
+        )
+        mock_http_client.post.return_value = create_mock_response({"work": sample_work_data})
+
+        service = WorksService(mock_http_client)
+        result = service.get("don:core:issue:123")
+
+        assert result.type == WorkType.TICKET
+        assert result.account == {"id": "don:core:account:123", "display_name": "Acme"}
+        assert result.rev_org == {"id": "don:core:rev_org:123", "display_name": "Acme"}
+        assert result.sentiment == "positive"
+        assert result.sentiment_summary == {"summary": "Customer is happy"}
+        assert result.sentiment_modified_date is not None
+        assert result.sla_summary == {"stage": "active", "remaining_time": 3600}
+        assert result.needs_response is True
+        assert result.channels == [{"id": 3, "label": "email"}, "plug"]
+        assert result.source_channel == {"id": 3, "label": "email"}
+        assert result.group == {"id": "don:core:group:123", "name": "Support"}
+        assert result.is_frozen is False
+        assert result.visibility == "external"
+
     def test_list_works(
         self,
         mock_http_client: MagicMock,
@@ -484,6 +543,26 @@ class TestListSincePageLimitClamp:
 
 class TestAsyncListSince:
     """Async variants for ``list_modified_since`` / ``list_created_since``."""
+
+    @pytest.mark.asyncio
+    async def test_async_get_raw_work_returns_unparsed_payload(self) -> None:
+        raw_payload = {
+            "work": {
+                "id": "don:core:work:1",
+                "type": "ticket",
+                "title": "Raw ticket",
+            },
+            "server_extra": {"unknown": True},
+        }
+        mock_async_client = AsyncMock()
+        mock_async_client.post.return_value = create_mock_response(raw_payload)
+
+        service = AsyncWorksService(mock_async_client)
+        result = await service.get_raw("don:core:work:1")
+
+        assert result == raw_payload
+        _, kwargs = mock_async_client.post.call_args
+        assert kwargs["data"] == {"id": "don:core:work:1"}
 
     @pytest.mark.asyncio
     async def test_async_list_modified_since_early_exit(self) -> None:

--- a/tests/unit/services/test_works.py
+++ b/tests/unit/services/test_works.py
@@ -114,7 +114,7 @@ class TestWorksService:
                 "type": "ticket",
                 "account": {"id": "don:core:account:123", "display_name": "Acme"},
                 "rev_org": {"id": "don:core:rev_org:123", "display_name": "Acme"},
-                "sentiment": "positive",
+                "sentiment": {"id": 5, "label": "Frustrated", "ordinal": 5},
                 "sentiment_summary": {"summary": "Customer is happy"},
                 "sentiment_modified_date": "2024-01-16T10:00:00Z",
                 "sla_summary": {"stage": "active", "remaining_time": 3600},
@@ -123,7 +123,7 @@ class TestWorksService:
                 "source_channel": {"id": 3, "label": "email"},
                 "group": {"id": "don:core:group:123", "name": "Support"},
                 "is_frozen": False,
-                "visibility": "external",
+                "visibility": {"id": 2, "label": "external", "ordinal": 2},
             }
         )
         mock_http_client.post.return_value = create_mock_response({"work": sample_work_data})
@@ -134,7 +134,7 @@ class TestWorksService:
         assert result.type == WorkType.TICKET
         assert result.account == {"id": "don:core:account:123", "display_name": "Acme"}
         assert result.rev_org == {"id": "don:core:rev_org:123", "display_name": "Acme"}
-        assert result.sentiment == "positive"
+        assert result.sentiment == {"id": 5, "label": "Frustrated", "ordinal": 5}
         assert result.sentiment_summary == {"summary": "Customer is happy"}
         assert result.sentiment_modified_date is not None
         assert result.sla_summary == {"stage": "active", "remaining_time": 3600}
@@ -143,7 +143,7 @@ class TestWorksService:
         assert result.source_channel == {"id": 3, "label": "email"}
         assert result.group == {"id": "don:core:group:123", "name": "Support"}
         assert result.is_frozen is False
-        assert result.visibility == "external"
+        assert result.visibility == {"id": 2, "label": "external", "ordinal": 2}
 
     def test_list_works(
         self,

--- a/tests/unit/services/test_works.py
+++ b/tests/unit/services/test_works.py
@@ -100,7 +100,8 @@ class TestWorksService:
 
         assert result == raw_payload
         mock_http_client.post.assert_called_once()
-        _, kwargs = mock_http_client.post.call_args
+        (endpoint,), kwargs = mock_http_client.post.call_args
+        assert endpoint == "/works.get"
         assert kwargs["data"] == {"id": "don:core:issue:123"}
 
     def test_work_parses_ticket_integration_fields(
@@ -136,7 +137,7 @@ class TestWorksService:
         assert result.rev_org == {"id": "don:core:rev_org:123", "display_name": "Acme"}
         assert result.sentiment == {"id": 5, "label": "Frustrated", "ordinal": 5}
         assert result.sentiment_summary == {"summary": "Customer is happy"}
-        assert result.sentiment_modified_date is not None
+        assert result.sentiment_modified_date == datetime(2024, 1, 16, 10, 0, tzinfo=UTC)
         assert result.sla_summary == {"stage": "active", "remaining_time": 3600}
         assert result.needs_response is True
         assert result.channels == [{"id": 3, "label": "email"}, "plug"]
@@ -144,6 +145,37 @@ class TestWorksService:
         assert result.group == {"id": "don:core:group:123", "name": "Support"}
         assert result.is_frozen is False
         assert result.visibility == {"id": 2, "label": "external", "ordinal": 2}
+
+    def test_work_parses_string_ticket_integration_fields(
+        self,
+        mock_http_client: MagicMock,
+        sample_work_data: dict[str, Any],
+    ) -> None:
+        """Test ticket integration fields when the API returns bare strings."""
+        sample_work_data.update(
+            {
+                "type": "ticket",
+                "account": "don:core:account:123",
+                "rev_org": "don:core:rev_org:123",
+                "sentiment": "frustrated",
+                "sentiment_summary": "Customer is unhappy",
+                "source_channel": "email",
+                "group": "support",
+                "visibility": "external",
+            }
+        )
+        mock_http_client.post.return_value = create_mock_response({"work": sample_work_data})
+
+        service = WorksService(mock_http_client)
+        result = service.get("don:core:issue:123")
+
+        assert result.account == "don:core:account:123"
+        assert result.rev_org == "don:core:rev_org:123"
+        assert result.sentiment == "frustrated"
+        assert result.sentiment_summary == "Customer is unhappy"
+        assert result.source_channel == "email"
+        assert result.group == "support"
+        assert result.visibility == "external"
 
     def test_list_works(
         self,
@@ -561,7 +593,8 @@ class TestAsyncListSince:
         result = await service.get_raw("don:core:work:1")
 
         assert result == raw_payload
-        _, kwargs = mock_async_client.post.call_args
+        (endpoint,), kwargs = mock_async_client.post.call_args
+        assert endpoint == "/works.get"
         assert kwargs["data"] == {"id": "don:core:work:1"}
 
     @pytest.mark.asyncio

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2,6 +2,7 @@
 
 from devrev.client import AsyncDevRevClient, DevRevClient
 from devrev.config import APIVersion, DevRevConfig
+from devrev.services.survey_responses import AsyncSurveyResponsesService, SurveyResponsesService
 
 
 class TestDevRevClient:
@@ -45,6 +46,11 @@ class TestDevRevClient:
         with DevRevClient() as client:
             assert client._config is not None
 
+    def test_client_exposes_survey_responses_service(self, mock_env_vars: dict[str, str]) -> None:
+        """Test client exposes the public survey responses service."""
+        client = DevRevClient()
+        assert isinstance(client.survey_responses, SurveyResponsesService)
+
 
 class TestAsyncDevRevClient:
     """Tests for AsyncDevRevClient class."""
@@ -66,6 +72,13 @@ class TestAsyncDevRevClient:
         )
         assert client._config.api_token.get_secret_value() == "explicit-token"
         assert client._config.timeout == 90
+
+    def test_async_client_exposes_survey_responses_service(
+        self, mock_env_vars: dict[str, str]
+    ) -> None:
+        """Test async client exposes the public survey responses service."""
+        client = AsyncDevRevClient()
+        assert isinstance(client.survey_responses, AsyncSurveyResponsesService)
 
 
 class TestAPIVersionPrecedence:


### PR DESCRIPTION
## Overview

Enhances ticket SDK coverage for the gaps described in #220 by adding typed support for additional ticket/work fields, a supported raw-response escape hatch, and first-class survey response listing.

Closes #220

## What changed

### SDK models and services

- Added optional ticket integration fields to the `Work` model, including account/rev org association, sentiment, SLA summary, response-needed state, channels, group, frozen state, and visibility.
- Added `WorksService.get_raw(...)` and `AsyncWorksService.get_raw(...)` for supported access to unparsed `/works.get` payloads without using private `_http` internals.
- Added new sync/async `survey_responses.list(...)` support for `/surveys.responses.list`.
- Added typed survey response request/response models and public exports.
- Exposed `client.survey_responses` on both sync and async clients.

### Documentation

- Documented `works.get_raw(...)` and ticket account association guidance.
- Added Survey Responses service docs and mkdocs navigation.
- Updated README examples and changelog.

### Tests

- Added unit coverage for raw work retrieval and optional ticket fields.
- Added unit coverage for survey response listing, duplicate object filter merging, async support, and preservation of unknown API fields.
- Added client exposure tests for the new survey response service.

## Validation performed

- `python3 -m pytest tests/unit/services/test_works.py tests/unit/services/test_survey_responses.py tests/unit/test_client.py` — 62 passed
- `python3 -m pytest tests/unit` — 1200 passed
- `python3 -m ruff check . && python3 -m ruff format --check .` — passed
- `python3 -m mypy src/devrev/models/works.py src/devrev/models/survey_responses.py src/devrev/services/works.py src/devrev/services/survey_responses.py src/devrev/client.py src/devrev/services/__init__.py src/devrev/models/__init__.py tests/unit/services/test_works.py tests/unit/services/test_survey_responses.py tests/unit/test_client.py` — passed
- `git diff --check` and `git diff --cached --check` — passed

## Notes

- Project-wide `python3 -m mypy .` is currently blocked by an existing duplicate module-name issue in `examples/integrations/*/main.py`, unrelated to this change.
- `python3 -m mkdocs build --strict` could not be run in this environment because `mkdocs` is not installed.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author