### PR TITLE
[CSS-1041] Add DevRev webhook management MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This SDK is generated and maintained from the official DevRev OpenAPI specificat
 
 ### MCP Server (AI Integration)
 
-- ✅ **78+ MCP Tools** — Full CRUD for tickets, accounts, users, articles, and all DevRev resources
+- ✅ **83+ MCP Tools** — Full CRUD for tickets, accounts, users, articles, webhooks, and all DevRev resources
 - ✅ **7 Resource Templates** — `devrev://` URI scheme for AI-accessible data browsing
 - ✅ **8 Workflow Prompts** — Pre-built triage, escalation, investigation, and reporting workflows
 - ✅ **3 Transport Modes** — stdio (local), Streamable HTTP (production), SSE (legacy)
@@ -650,7 +650,7 @@ The DevRev MCP Server exposes the full DevRev platform as [Model Context Protoco
 
 ### MCP Server Features
 
-- **78+ MCP Tools** — Full CRUD for tickets, accounts, users, conversations, articles, parts, tags, groups, timeline, links, SLAs, plus beta tools (search, recommendations, incidents, engagements)
+- **83+ MCP Tools** — Full CRUD for tickets, accounts, users, conversations, articles, parts, tags, groups, timeline, links, SLAs, webhooks, plus beta tools (search, recommendations, incidents, engagements)
 - **7 Resource Templates** — `devrev://` URI scheme for browsing tickets, accounts, articles, users, parts, conversations
 - **8 Workflow Prompts** — Triage, draft response, escalate, summarize account, investigate, weekly report, find similar, onboard customer
 - **3 Transports** — stdio (local dev), Streamable HTTP (production), SSE (legacy)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [3.1.0] - 2026-06-16
+
+### Added
+
+- **Webhook management MCP tools** (CSS-1041) — New `devrev_webhooks_*` MCP
+  tools exposing the existing `WebhooksService` through the MCP server:
+  `devrev_webhooks_list` and `devrev_webhooks_get` (read-only), plus
+  `devrev_webhooks_create`, `devrev_webhooks_update`, and
+  `devrev_webhooks_delete` (registered only when destructive tools are
+  enabled). The module follows the established tool conventions (DON ID
+  validation, paginated list responses, `WebhookStatus` resolution on update)
+  and is registered in the core (non-beta) tool block. Documentation in
+  `docs/mcp/tools-reference.md` now covers all five tools plus an advisory
+  section on event types, target URL requirements, the signing `secret`, and
+  the webhook status lifecycle.
+
 ## [3.0.1] - 2026-04-22
 
 ### Changed

--- a/docs/mcp/tools-reference.md
+++ b/docs/mcp/tools-reference.md
@@ -6,7 +6,7 @@ icon: material/tools
 
 Complete reference of all MCP capabilities provided by the DevRev MCP Server.
 
-## Tools (83+)
+## Tools (88+)
 
 Tools are the primary way AI assistants interact with DevRev. Each tool maps to one or more DevRev API endpoints.
 
@@ -148,12 +148,37 @@ issues (engineering), and tasks.
 
 ### Webhooks
 
+Webhooks deliver DevRev events to an external HTTPS endpoint. Each webhook has a
+target `url`, an optional list of `event_types` to subscribe to (defaults to all
+events), and an optional `secret` used to sign payloads so the receiver can
+verify authenticity. A webhook's `status` moves through `unverified` → `active`
+once DevRev confirms the endpoint, and can be set to `inactive` to pause
+delivery.
+
 | Tool | Description |
 |------|-------------|
 | `devrev_webhooks_list` | List webhooks |
 | `devrev_webhooks_get` | Get webhook details |
 | `devrev_webhooks_create` | Create a webhook |
-| `devrev_webhooks_update` | Update a webhook |
+| `devrev_webhooks_update` | Update a webhook (url, event types, status) |
+| `devrev_webhooks_delete` | Delete a webhook |
+
+**Managing webhooks**
+
+- **Target URL** must be a publicly reachable HTTPS endpoint that responds to
+  DevRev's verification handshake; until it does, the webhook stays
+  `unverified` and no events are delivered.
+- **Event types** scope which events are sent. Omit `event_types` on create to
+  receive all event types, or pass a specific list (e.g. `work_created`,
+  `work_updated`) to narrow delivery.
+- **Secret** is a shared signing key — store it as a secret on the receiving
+  service and use it to verify each payload's signature. Never log or commit it.
+- **Status lifecycle**: `unverified` (awaiting handshake) → `active` (delivering)
+  ↔ `inactive` (paused). Use `devrev_webhooks_update` with `status` to pause or
+  resume a webhook.
+- **Typical workflow**: `devrev_webhooks_create` (register the endpoint) → verify
+  the endpoint so it becomes `active` → `devrev_webhooks_list` / `devrev_webhooks_get`
+  to confirm configuration → `devrev_webhooks_delete` when it is no longer needed.
 
 ### Beta Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "devrev-Python-SDK"
-version = "3.0.3"
+version = "3.1.0"
 description = "A modern, type-safe Python SDK for the DevRev API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/devrev_mcp/server.py
+++ b/src/devrev_mcp/server.py
@@ -249,6 +249,7 @@ from devrev_mcp.tools import slas as _slas_tools  # noqa: E402, F401
 from devrev_mcp.tools import tags as _tags_tools  # noqa: E402, F401
 from devrev_mcp.tools import timeline as _timeline_tools  # noqa: E402, F401
 from devrev_mcp.tools import users as _users_tools  # noqa: E402, F401
+from devrev_mcp.tools import webhooks as _webhooks_tools  # noqa: E402, F401
 from devrev_mcp.tools import works as _works_tools  # noqa: E402, F401
 
 # Beta tools (only if beta tools are enabled)

--- a/src/devrev_mcp/tools/webhooks.py
+++ b/src/devrev_mcp/tools/webhooks.py
@@ -1,0 +1,153 @@
+"""MCP tools for DevRev webhook operations."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import Context
+
+from devrev.exceptions import DevRevError
+from devrev.models.webhooks import (
+    WebhooksCreateRequest,
+    WebhooksDeleteRequest,
+    WebhooksGetRequest,
+    WebhooksListRequest,
+    WebhookStatus,
+    WebhooksUpdateRequest,
+)
+from devrev_mcp.server import _config, mcp
+from devrev_mcp.utils.don_id import validate_don_id
+from devrev_mcp.utils.errors import format_devrev_error
+from devrev_mcp.utils.formatting import serialize_model, serialize_models
+from devrev_mcp.utils.pagination import clamp_page_size
+
+logger = logging.getLogger(__name__)
+
+
+@mcp.tool()
+async def devrev_webhooks_list(
+    ctx: Context[Any, Any, Any],
+    cursor: str | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """List DevRev webhooks.
+
+    Args:
+        cursor: Pagination cursor from a previous response.
+        limit: Maximum number of items to return (default: 25, max: 100).
+    """
+    app = ctx.request_context.lifespan_context
+    try:
+        request = WebhooksListRequest(
+            cursor=cursor,
+            limit=clamp_page_size(
+                limit, default=app.config.default_page_size, maximum=app.config.max_page_size
+            ),
+        )
+        webhooks = await app.get_client().webhooks.list(request)
+        items = serialize_models(list(webhooks))
+        return {"count": len(items), "webhooks": items}
+    except DevRevError as e:
+        raise RuntimeError(format_devrev_error(e)) from e
+
+
+@mcp.tool()
+async def devrev_webhooks_get(
+    ctx: Context[Any, Any, Any],
+    id: str,
+) -> dict[str, Any]:
+    """Get a DevRev webhook by ID.
+
+    Args:
+        id: Webhook ID (e.g., "don:integration:dvrv-us-1:devo/1:webhook/123").
+    """
+    validate_don_id(id, "webhook", "devrev_webhooks_get")
+    app = ctx.request_context.lifespan_context
+    try:
+        request = WebhooksGetRequest(id=id)
+        webhook = await app.get_client().webhooks.get(request)
+        return serialize_model(webhook)
+    except DevRevError as e:
+        raise RuntimeError(format_devrev_error(e)) from e
+
+
+# Destructive tools (only registered when enabled)
+if _config.enable_destructive_tools:
+
+    @mcp.tool()
+    async def devrev_webhooks_create(
+        ctx: Context[Any, Any, Any],
+        url: str,
+        event_types: list[str] | None = None,
+        secret: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a new DevRev webhook.
+
+        Args:
+            url: Target URL that will receive webhook event POSTs.
+            event_types: Event types to subscribe to (default: all events).
+            secret: Shared secret used to sign and verify webhook payloads.
+        """
+        app = ctx.request_context.lifespan_context
+        try:
+            request = WebhooksCreateRequest(url=url, event_types=event_types, secret=secret)
+            webhook = await app.get_client().webhooks.create(request)
+            return serialize_model(webhook)
+        except DevRevError as e:
+            raise RuntimeError(format_devrev_error(e)) from e
+
+    @mcp.tool()
+    async def devrev_webhooks_update(
+        ctx: Context[Any, Any, Any],
+        id: str,
+        url: str | None = None,
+        event_types: list[str] | None = None,
+        status: str | None = None,
+    ) -> dict[str, Any]:
+        """Update a DevRev webhook.
+
+        Args:
+            id: Webhook ID to update.
+            url: New target URL.
+            event_types: New list of event types to subscribe to.
+            status: New status (active, inactive, unverified).
+        """
+        validate_don_id(id, "webhook", "devrev_webhooks_update")
+        app = ctx.request_context.lifespan_context
+        try:
+            resolved_status: WebhookStatus | None = None
+            if status is not None:
+                try:
+                    resolved_status = WebhookStatus(status.lower())
+                except ValueError as e:
+                    raise RuntimeError(
+                        f"Invalid webhook status '{status}'. "
+                        "Valid values: active, inactive, unverified."
+                    ) from e
+            request = WebhooksUpdateRequest(
+                id=id, url=url, event_types=event_types, status=resolved_status
+            )
+            webhook = await app.get_client().webhooks.update(request)
+            return serialize_model(webhook)
+        except DevRevError as e:
+            raise RuntimeError(format_devrev_error(e)) from e
+
+    @mcp.tool()
+    async def devrev_webhooks_delete(
+        ctx: Context[Any, Any, Any],
+        id: str,
+    ) -> dict[str, Any]:
+        """Delete a DevRev webhook.
+
+        Args:
+            id: Webhook ID to delete.
+        """
+        validate_don_id(id, "webhook", "devrev_webhooks_delete")
+        app = ctx.request_context.lifespan_context
+        try:
+            request = WebhooksDeleteRequest(id=id)
+            await app.get_client().webhooks.delete(request)
+            return {"deleted": True, "id": id}
+        except DevRevError as e:
+            raise RuntimeError(format_devrev_error(e)) from e

--- a/src/devrev_mcp/utils/don_id.py
+++ b/src/devrev_mcp/utils/don_id.py
@@ -35,6 +35,7 @@ DON_TYPE_MAP: dict[str, str] = {
     "qa": "question_answer",
     "question_answer": "question_answer",
     "timeline_entry": "timeline_entry",
+    "webhook": "webhook",
 }
 
 TOOL_SUGGESTIONS: dict[str, str] = {
@@ -57,6 +58,7 @@ TOOL_SUGGESTIONS: dict[str, str] = {
     "qa": "devrev_question_answers_get",
     "question_answer": "devrev_question_answers_get",
     "timeline_entry": "devrev_timeline_get",
+    "webhook": "devrev_webhooks_get",
 }
 
 

--- a/tests/unit/mcp/conftest.py
+++ b/tests/unit/mcp/conftest.py
@@ -176,6 +176,14 @@ def mock_client():
     client.slas.update = AsyncMock()
     client.slas.transition = AsyncMock()
 
+    # Webhooks service
+    client.webhooks = AsyncMock()
+    client.webhooks.list = AsyncMock()
+    client.webhooks.get = AsyncMock()
+    client.webhooks.create = AsyncMock()
+    client.webhooks.update = AsyncMock()
+    client.webhooks.delete = AsyncMock()
+
     # Question Answers service
     client.question_answers = AsyncMock()
     client.question_answers.list = AsyncMock()

--- a/tests/unit/mcp/test_tools_webhooks.py
+++ b/tests/unit/mcp/test_tools_webhooks.py
@@ -1,0 +1,207 @@
+"""Unit tests for DevRev MCP webhook tools."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from devrev.exceptions import NotFoundError, ValidationError
+from devrev_mcp.tools.webhooks import (
+    devrev_webhooks_create,
+    devrev_webhooks_delete,
+    devrev_webhooks_get,
+    devrev_webhooks_list,
+    devrev_webhooks_update,
+)
+
+WEBHOOK_ID = "don:integration:dvrv-us-1:devo/1:webhook/123"
+
+
+def _make_mock_webhook(data: dict | None = None) -> MagicMock:
+    """Create a mock Webhook model with a model_dump method."""
+    mock = MagicMock()
+    default_data = {
+        "id": WEBHOOK_ID,
+        "url": "https://example.com/hook",
+        "status": "active",
+        "event_types": ["work_created"],
+        "created_date": "2026-01-01T00:00:00Z",
+        "modified_date": "2026-01-01T00:00:00Z",
+    }
+    if data:
+        default_data.update(data)
+    mock.model_dump.return_value = default_data
+    return mock
+
+
+class TestWebhooksListTool:
+    """Tests for devrev_webhooks_list tool."""
+
+    async def test_webhooks_list_success(self, mock_ctx, mock_client):
+        """Test listing webhooks with results."""
+        webhook = _make_mock_webhook()
+        mock_client.webhooks.list.return_value = [webhook]
+
+        result = await devrev_webhooks_list(mock_ctx)
+
+        assert result["count"] == 1
+        assert len(result["webhooks"]) == 1
+        assert result["webhooks"][0]["id"] == WEBHOOK_ID
+        assert result["webhooks"][0]["url"] == "https://example.com/hook"
+        mock_client.webhooks.list.assert_called_once()
+
+    async def test_webhooks_list_empty(self, mock_ctx, mock_client):
+        """Test listing webhooks with empty results."""
+        mock_client.webhooks.list.return_value = []
+
+        result = await devrev_webhooks_list(mock_ctx)
+
+        assert result["count"] == 0
+        assert result["webhooks"] == []
+        mock_client.webhooks.list.assert_called_once()
+
+    async def test_webhooks_list_with_pagination(self, mock_ctx, mock_client):
+        """Test listing webhooks with pagination parameters."""
+        wh1 = _make_mock_webhook({"id": "wh-1"})
+        wh2 = _make_mock_webhook({"id": "wh-2"})
+        mock_client.webhooks.list.return_value = [wh1, wh2]
+
+        result = await devrev_webhooks_list(mock_ctx, cursor="cursor-123", limit=10)
+
+        assert result["count"] == 2
+        assert len(result["webhooks"]) == 2
+        mock_client.webhooks.list.assert_called_once()
+
+    async def test_webhooks_list_error(self, mock_ctx, mock_client):
+        """Test listing webhooks with error."""
+        mock_client.webhooks.list.side_effect = NotFoundError("Not found", status_code=404)
+
+        with pytest.raises(RuntimeError, match="Not found"):
+            await devrev_webhooks_list(mock_ctx)
+
+
+class TestWebhooksGetTool:
+    """Tests for devrev_webhooks_get tool."""
+
+    async def test_webhooks_get_success(self, mock_ctx, mock_client):
+        """Test getting a webhook successfully."""
+        mock_client.webhooks.get.return_value = _make_mock_webhook()
+
+        result = await devrev_webhooks_get(mock_ctx, id=WEBHOOK_ID)
+
+        assert result["id"] == WEBHOOK_ID
+        assert result["url"] == "https://example.com/hook"
+        mock_client.webhooks.get.assert_called_once()
+
+    async def test_webhooks_get_error(self, mock_ctx, mock_client):
+        """Test getting a non-existent webhook."""
+        mock_client.webhooks.get.side_effect = NotFoundError("Webhook not found", status_code=404)
+
+        with pytest.raises(RuntimeError, match="Webhook not found"):
+            await devrev_webhooks_get(mock_ctx, id=WEBHOOK_ID)
+
+    async def test_webhooks_get_wrong_id_type(self, mock_ctx, mock_client):
+        """Test getting a webhook with a non-webhook DON ID raises."""
+        with pytest.raises(RuntimeError, match="expects"):
+            await devrev_webhooks_get(mock_ctx, id="don:core:dvrv-us-1:devo/1:account/1")
+        mock_client.webhooks.get.assert_not_called()
+
+
+class TestWebhooksCreateTool:
+    """Tests for devrev_webhooks_create tool."""
+
+    async def test_webhooks_create_minimal(self, mock_ctx, mock_client):
+        """Test creating a webhook with minimal parameters."""
+        mock_client.webhooks.create.return_value = _make_mock_webhook()
+
+        result = await devrev_webhooks_create(mock_ctx, url="https://example.com/hook")
+
+        assert result["url"] == "https://example.com/hook"
+        mock_client.webhooks.create.assert_called_once()
+
+    async def test_webhooks_create_full(self, mock_ctx, mock_client):
+        """Test creating a webhook with all parameters."""
+        mock_client.webhooks.create.return_value = _make_mock_webhook(
+            {"event_types": ["work_created", "work_updated"]}
+        )
+
+        result = await devrev_webhooks_create(
+            mock_ctx,
+            url="https://example.com/hook",
+            event_types=["work_created", "work_updated"],
+            secret="s3cr3t",
+        )
+
+        assert result["event_types"] == ["work_created", "work_updated"]
+        mock_client.webhooks.create.assert_called_once()
+
+    async def test_webhooks_create_validation_error(self, mock_ctx, mock_client):
+        """Test creating a webhook with validation error."""
+        mock_client.webhooks.create.side_effect = ValidationError("Invalid url", status_code=400)
+
+        with pytest.raises(RuntimeError, match="Invalid url"):
+            await devrev_webhooks_create(mock_ctx, url="not-a-url")
+
+
+class TestWebhooksUpdateTool:
+    """Tests for devrev_webhooks_update tool."""
+
+    async def test_webhooks_update_success(self, mock_ctx, mock_client):
+        """Test updating a webhook successfully."""
+        mock_client.webhooks.update.return_value = _make_mock_webhook(
+            {"url": "https://new.example.com/hook"}
+        )
+
+        result = await devrev_webhooks_update(
+            mock_ctx, id=WEBHOOK_ID, url="https://new.example.com/hook"
+        )
+
+        assert result["url"] == "https://new.example.com/hook"
+        mock_client.webhooks.update.assert_called_once()
+
+    async def test_webhooks_update_status(self, mock_ctx, mock_client):
+        """Test updating a webhook status."""
+        mock_client.webhooks.update.return_value = _make_mock_webhook({"status": "inactive"})
+
+        result = await devrev_webhooks_update(mock_ctx, id=WEBHOOK_ID, status="inactive")
+
+        assert result["status"] == "inactive"
+        mock_client.webhooks.update.assert_called_once()
+
+    async def test_webhooks_update_invalid_status(self, mock_ctx, mock_client):
+        """Test updating a webhook with an invalid status raises."""
+        with pytest.raises(RuntimeError, match="Invalid webhook status"):
+            await devrev_webhooks_update(mock_ctx, id=WEBHOOK_ID, status="bogus")
+        mock_client.webhooks.update.assert_not_called()
+
+    async def test_webhooks_update_error(self, mock_ctx, mock_client):
+        """Test updating a webhook with error."""
+        mock_client.webhooks.update.side_effect = NotFoundError(
+            "Webhook not found", status_code=404
+        )
+
+        with pytest.raises(RuntimeError, match="Webhook not found"):
+            await devrev_webhooks_update(mock_ctx, id=WEBHOOK_ID, url="https://x.example.com")
+
+
+class TestWebhooksDeleteTool:
+    """Tests for devrev_webhooks_delete tool."""
+
+    async def test_webhooks_delete_success(self, mock_ctx, mock_client):
+        """Test deleting a webhook successfully."""
+        mock_client.webhooks.delete.return_value = None
+
+        result = await devrev_webhooks_delete(mock_ctx, id=WEBHOOK_ID)
+
+        assert result == {"deleted": True, "id": WEBHOOK_ID}
+        mock_client.webhooks.delete.assert_called_once()
+
+    async def test_webhooks_delete_error(self, mock_ctx, mock_client):
+        """Test deleting a webhook with error."""
+        mock_client.webhooks.delete.side_effect = NotFoundError(
+            "Webhook not found", status_code=404
+        )
+
+        with pytest.raises(RuntimeError, match="Webhook not found"):
+            await devrev_webhooks_delete(mock_ctx, id=WEBHOOK_ID)

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "devrev-python-sdk"
-version = "3.0.3"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

Adds the MCP tool layer for DevRev **webhook management** (CSS-1041). The SDK `WebhooksService` already existed; this PR exposes it through the MCP server so AI assistants can manage webhooks. Read-only tools are always available; the create/update/delete tools are guarded by `enable_destructive_tools`, matching the existing `slas`/`tags` modules.

## Files added/changed

**Added**
- `src/devrev_mcp/tools/webhooks.py` — 5 MCP tools: `devrev_webhooks_list`, `devrev_webhooks_get`, `devrev_webhooks_create`, `devrev_webhooks_update`, `devrev_webhooks_delete`.
- `tests/unit/mcp/test_tools_webhooks.py` — 16 unit tests (success, empty, pagination, get, wrong-id-type, create minimal/full, update + status + invalid-status, delete, and error paths). New-module coverage: **99%**.

**Changed**
- `src/devrev_mcp/server.py` — register `webhooks` in the core (non-beta) tool block.
- `src/devrev_mcp/utils/don_id.py` — add `webhook` entries to the DON ID type map and tool suggestions.
- `tests/unit/mcp/conftest.py` — add the `webhooks` service to the mock client.
- `docs/mcp/tools-reference.md` — reconcile the Webhooks table (now lists all 5 tools incl. delete), add an advisory subsection (event types, target URL, signing secret, status lifecycle, typical workflow), bump the tool count.
- `README.md` — add Webhooks to MCP tool coverage.
- `docs/changelog.md` — add the `3.1.0` entry.
- `pyproject.toml` / `uv.lock` — version bump `3.0.3` -> `3.1.0` (MINOR, new feature).

## Testing

- `uv run pytest tests/unit/mcp/test_tools_webhooks.py -q` -> `16 passed`
- Full suite: `uv run pytest -q` -> `1238 passed, 175 skipped`
- `uv run ruff check .` -> clean; `uv run ruff format --check` -> clean
- `uv run mypy src/` -> `Success: no issues found in 119 source files`

Related: CSS-1041
Linear: https://linear.app/augmentcode/issue/CSS-1041


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.staging.augmentcode.com/session?agentId=01KV7JBJX2XF9JRMKHWE9G7F7H&panel=chat)