### PR TITLE
[CSS-1042] Reconcile dotted webhook event-type examples to underscore form

### DIFF
--- a/docs/api/services/webhooks.md
+++ b/docs/api/services/webhooks.md
@@ -35,7 +35,7 @@ import os
 
 response = client.webhooks.create(
     url="https://your-server.com/webhooks/devrev",
-    event_types=["work.created", "work.updated"],
+    event_types=["work_created", "work_updated"],
     secret=os.environ["WEBHOOK_SECRET"],  # Never hardcode!
 )
 print(f"Created: {response.webhook.id}")
@@ -46,7 +46,7 @@ print(f"Created: {response.webhook.id}")
 ```python
 response = client.webhooks.update(
     id="don:integration:dvrv-us-1:devo/1:webhook/123",
-    event_types=["work.created", "work.updated", "work.deleted"],
+    event_types=["work_created", "work_updated", "work_deleted"],
 )
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [3.1.1] - 2026-06-16
+
+### Changed
+
+- **Webhook event-type examples reconciled to underscore form** (CSS-1042) —
+  Pre-existing examples and docs that used the dotted DevRev webhook
+  event-type form (`work.created`) now use the canonical underscore form
+  (`work_created`, `work_updated`, `work_deleted`, `conversation_created`),
+  matching the form DevRev sends in webhook payloads and the form already used
+  by the README, SDK docs, and the webhooks MCP advisory. This corrects a
+  latent bug in the Google Cloud Functions example, whose handler compared the
+  incoming payload `type` against dotted strings that never matched.
+  Docs/examples only; no SDK or MCP behavior change.
+
 ## [3.1.0] - 2026-06-16
 
 ### Added

--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -123,11 +123,11 @@ class WebhookHandler:
 # Usage example
 webhook = WebhookHandler(secret="your-webhook-secret")
 
-@webhook.on("work.created")
+@webhook.on("work_created")
 def handle_work_created(data):
     print(f"New work item: {data['work']['title']}")
 
-@webhook.on("work.updated")
+@webhook.on("work_updated")
 def handle_work_updated(data):
     print(f"Work updated: {data['work']['id']}")
 ```

--- a/docs/examples/integrations.md
+++ b/docs/examples/integrations.md
@@ -121,7 +121,7 @@ def handle_webhook(request: Request):
     data = request.get_json()
     event_type = data.get("type")
     
-    if event_type == "work.created":
+    if event_type == "work_created":
         work = data.get("work", {})
         print(f"New work item: {work.get('title')}")
         

--- a/examples/integrations/cloud_functions/main.py
+++ b/examples/integrations/cloud_functions/main.py
@@ -41,17 +41,17 @@ def handle_webhook(request: Request) -> tuple[dict[str, Any], int]:
     print(f"Received webhook: {event_type}")
 
     # Process different event types
-    if event_type == "work.created":
+    if event_type == "work_created":
         work = data.get("work", {})
         print(f"New work item created: {work.get('title')}")
         # Add your processing logic here
 
-    elif event_type == "work.updated":
+    elif event_type == "work_updated":
         work = data.get("work", {})
         print(f"Work item updated: {work.get('id')}")
         # Add your processing logic here
 
-    elif event_type == "conversation.created":
+    elif event_type == "conversation_created":
         conv = data.get("conversation", {})
         print(f"New conversation: {conv.get('id')}")
         # Add your processing logic here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "devrev-Python-SDK"
-version = "3.1.0"
+version = "3.1.1"
 description = "A modern, type-safe Python SDK for the DevRev API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/services/conftest.py
+++ b/tests/unit/services/conftest.py
@@ -123,7 +123,7 @@ def sample_webhook_data() -> dict[str, Any]:
     return {
         "id": "don:core:webhook:123",
         "url": "https://example.com/webhook",
-        "event_types": ["work.created", "work.updated"],
+        "event_types": ["work_created", "work_updated"],
     }
 
 

--- a/tests/unit/services/test_webhooks.py
+++ b/tests/unit/services/test_webhooks.py
@@ -30,7 +30,7 @@ class TestWebhooksService:
         service = WebhooksService(mock_http_client)
         request = WebhooksCreateRequest(
             url="https://example.com/webhook",
-            event_types=["work.created", "work.updated"],
+            event_types=["work_created", "work_updated"],
         )
         result = service.create(request)
 

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "devrev-python-sdk"
-version = "3.1.0"
+version = "3.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

The canonical DevRev webhook event-type form is **underscore** (`work_created`, `work_updated`, `work_deleted`, `conversation_created`) — this is the form DevRev sends in webhook payloads, and the form already used by the README, SDK docs, and the new webhooks MCP advisory (CSS-1041).

Several pre-existing examples/docs still used the **dotted** form (`work.created`), which was inconsistent. In the Google Cloud Functions example it was a latent bug: the handler compares the incoming payload `type` (which DevRev sends underscored) against dotted strings, so those branches never matched.

This PR reconciles all dotted DevRev webhook event-type string literals to the underscore form. Docs/examples + test fixtures only — no SDK or MCP logic changes.

## Files changed

- `docs/api/services/webhooks.md` — create/update examples
- `examples/integrations/cloud_functions/main.py` — handler branch comparisons (latent bug fix)
- `docs/examples/advanced.md` — `@webhook.on(...)` decorators
- `docs/examples/integrations.md` — Google Cloud Functions section
- `tests/unit/services/conftest.py` — `sample_webhook_data` fixture
- `tests/unit/services/test_webhooks.py` — create-webhook test request
- `pyproject.toml` + `uv.lock` — version bump `3.1.0` → `3.1.1` (docs/examples patch)
- `docs/changelog.md` — `3.1.1` entry

## Testing

All run via `uv` with all extras:

- `uv run --all-extras pytest -q` → **1238 passed, 175 skipped**
- `uv run --all-extras ruff check .` → All checks passed
- `uv run --all-extras ruff format --check .` → 232 files already formatted
- `uv run --all-extras mypy src/` → Success: no issues found in 119 source files

A repo-wide grep confirms no dotted DevRev webhook event-type literals remain (the only `work.created` left is in the changelog prose describing the old form).

Related: CSS-1042 — https://linear.app/augmentcode/issue/CSS-1042


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.staging.augmentcode.com/session?agentId=01KV7MX8RATWK7QE72MKJCHY0M&panel=chat)